### PR TITLE
core: Add missing stdint.h header to threads.c

### DIFF
--- a/src/core/threads.c
+++ b/src/core/threads.c
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <assert.h>
 #include <sys/syscall.h>
 #include <errno.h>


### PR DESCRIPTION
This is needed e.g. for uint64_t