### PR TITLE
i-raw: Fix buffer size

### DIFF
--- a/src/pipe/modules/i-raw/main.cc
+++ b/src/pipe/modules/i-raw/main.cc
@@ -210,7 +210,7 @@ void modify_roi_out(
   // load image if not happened yet
   const char *fname = dt_module_param_string(mod, 0);
   const char *filename = fname;
-  char tmpfn[512];
+  char tmpfn[1024];
   if(filename[0] != '/') // relative paths
   {
     snprintf(tmpfn, sizeof(tmpfn), "%s/%s", mod->graph->searchpath, fname);
@@ -452,7 +452,7 @@ int read_source(
 {
   const char *fname = dt_module_param_string(mod, 0);
   const char *filename = fname;
-  char tmpfn[512];
+  char tmpfn[1024];
   if(filename[0] != '/') // relative paths
   {
     snprintf(tmpfn, sizeof(tmpfn), "%s/%s", mod->graph->searchpath, fname);


### PR DESCRIPTION
```
pipe/modules/i-raw/main.cc:458:42: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
  458 |     snprintf(tmpfn, sizeof(tmpfn), "%s/%s", mod->graph->searchpath, fname);
      |                                          ^
pipe/modules/i-raw/main.cc:458:13: note: ‘snprintf’ output 2 or more bytes (assuming 513) into a destination of size 512
  458 |     snprintf(tmpfn, sizeof(tmpfn), "%s/%s", mod->graph->searchpath, fname);
      |     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

mod->graph->searchpath is size 512, so the destination buffer needs to
be bigger.