### PR TITLE
load_directory(tags): doesn't show deleted images

### DIFF
--- a/src/db/db.c
+++ b/src/db/db.c
@@ -230,7 +230,23 @@ void dt_db_load_directory(
           continue;
         }
       }
-      else ep_len -= 4; // remove '.cfg' suffix
+      else
+      {
+        ep_len -= 4; // remove '.cfg' suffix
+        // workaround for deleted tag's images (tag's folder not cleaned up)
+        if (ep->d_type == DT_LNK)
+        {
+          char imgfile[1500];
+          realpath(cfgfile, imgfile);
+          if (strlen(imgfile)>4) imgfile[strlen(imgfile)-4] = '\0';
+          struct stat statbuf = {0};
+          if(stat(imgfile, &statbuf))
+          {
+            db->image_cnt--;
+            continue;
+          }
+        }
+      }
     }
 
     // add base filename to string pool

--- a/src/gui/darkroom.c
+++ b/src/gui/darkroom.c
@@ -536,6 +536,7 @@ darkroom_enter()
   uint32_t imgid = dt_db_current_imgid(&vkdt.db);
   if(imgid == -1u) return 1;
   char graph_cfg[PATH_MAX+100];
+  graph_cfg[0] = '\0';
   dt_db_image_path(&vkdt.db, imgid, graph_cfg, sizeof(graph_cfg));
 
   // stat, if doesn't exist, load default


### PR DESCRIPTION
attempt to fix #36

workaround waiting for tags folder proper clean up.