### PR TITLE
tags: add image's tag list

### DIFF
--- a/src/db/db.h
+++ b/src/db/db.h
@@ -22,6 +22,7 @@ typedef struct dt_image_t
   uint32_t    thumbnail; // index into thumbnails->thumb[] or -1u
   uint16_t    rating;    // -1u reject 0 1 2 3 4 5 stars
   uint16_t    labels;    // each bit is one colour label flag, 1<<15 is selected bit
+  const char *tags;      // point into db.sp_tags.buf stringpool
 }
 dt_image_t;
 
@@ -72,6 +73,8 @@ typedef struct dt_db_t
 
   // string pool for image file names
   dt_stringpool_t sp_filename;
+  // string pool for image tags
+  dt_stringpool_t sp_tags;
 
   // TODO: light table edit history
 


### PR DESCRIPTION
Started to add the image's list of tags.
The attach part is more or less done.
The detach part is started but... 
First stringpool has no free feature. Attaching detaching a tag too many times would fulfill the list. Maybe not that important as it's reset at any change of collection.
Then, currently there is no collection flag to say if it's folder or tag collection. Searching where this should be done. Knowing that would also allow to display "detach image" instead of "delete image" accordingly.
Am I on a valid path ?