### PR TITLE
Add support for full-range yuv video

### DIFF
--- a/src/pipe/modules/i-vid/conv.comp
+++ b/src/pipe/modules/i-vid/conv.comp
@@ -5,10 +5,11 @@
 layout(local_size_x = DT_LOCAL_SIZE_X, local_size_y = DT_LOCAL_SIZE_Y, local_size_z = 1) in;
 layout(std140, set = 0, binding = 1) uniform params_t
 {
-  int color; // bt.709, bt.2020
-  int trc;   // linear, bt.709, smpte2084, HLG
-  int bits;  // 8, 10, 12, 16
-  int chr;   // 420, 422, 444, we don't care here
+  int color;    // bt.709, bt.2020
+  int trc;      // linear, bt.709, smpte2084, HLG
+  int bits;     // 8, 10, 12, 16
+  int chr;      // 420, 422, 444, we don't care here
+  int colrange; // 16-235/240, 0-255
 } params;
 
 layout(set = 1, binding = 0) uniform sampler2D img_in[];
@@ -58,6 +59,7 @@ main()
         1.1643835616, 2.1124017857, 0.0000000000);
     const vec3 YCbCrToRGBzero = vec3(-0.972945075, 0.301482665, -1.133402218);
     vec3 YCbCr = vec3(Y,u,v);
+    if(params.colrange == 1) YCbCr = (YCbCr*vec3(219.0/255.0, 224.0/255.0, 224.0/255.0) + 16.0/255.0);
     vec3 RGBFullRange = YCbCr * YCbCrToRGBmatrix + YCbCrToRGBzero;
     rgb = RGBFullRange;//clamp(RGBFullRange, vec3(0.0), vec3(1.0));
   }

--- a/src/pipe/modules/i-vid/main.c
+++ b/src/pipe/modules/i-vid/main.c
@@ -62,10 +62,11 @@ parse_parameters(
     dt_module_t *mod,
     vid_data_t  *d)
 {
-  int *p_colour = (int *)dt_module_param_int(mod, dt_module_get_param(mod->so, dt_token("colour")));
-  int *p_trc    = (int *)dt_module_param_int(mod, dt_module_get_param(mod->so, dt_token("trc")));
-  int *p_bits   = (int *)dt_module_param_int(mod, dt_module_get_param(mod->so, dt_token("bitdepth")));
-  int *p_chroma = (int *)dt_module_param_int(mod, dt_module_get_param(mod->so, dt_token("chroma")));
+  int *p_colour   = (int *)dt_module_param_int(mod, dt_module_get_param(mod->so, dt_token("colour")));
+  int *p_trc      = (int *)dt_module_param_int(mod, dt_module_get_param(mod->so, dt_token("trc")));
+  int *p_bits     = (int *)dt_module_param_int(mod, dt_module_get_param(mod->so, dt_token("bitdepth")));
+  int *p_chroma   = (int *)dt_module_param_int(mod, dt_module_get_param(mod->so, dt_token("chroma")));
+  int *p_colrange = (int *)dt_module_param_int(mod, dt_module_get_param(mod->so, dt_token("colrange")));
 
   switch(d->fmtc->streams[d->video_idx]->codecpar->format)
   {
@@ -106,6 +107,18 @@ parse_parameters(
       break;
     default:
       p_chroma[0] = 3; // unsupported
+  }
+  switch(d->fmtc->streams[d->video_idx]->codecpar->color_range)
+  { 
+    case AVCOL_RANGE_UNSPECIFIED:
+    case AVCOL_RANGE_MPEG:
+      p_colrange[0] = 0;
+      break;
+    case AVCOL_RANGE_JPEG:
+      p_colrange[0] = 1;
+      break;
+    default:
+      p_colrange[0] = 2; // unsupported
   }
 
   // enum AVCodecID vcodec = d->fmtc->streams[d->video_idx]->codecpar->codec_id;

--- a/src/pipe/modules/i-vid/params
+++ b/src/pipe/modules/i-vid/params
@@ -2,4 +2,5 @@ colour:int:1:0
 trc:int:1:1
 bitdepth:int:1:0
 chroma:int:1:0
+colrange:int:1:0
 filename:string:256:test.mp4


### PR DESCRIPTION
The h264 .mov files from my Olympus E-M1 II, and probably some of other DSLR / mirrorless, use the full scale (0-255) yuv encoding. This patch rescales the values to the 16-235/240 range expected by the rgb conversion matrix.

A short sample .mov that I used for testing is attached:

https://github.com/hanatos/vkdt/assets/3238173/eeb2e434-7221-4384-be2d-8631844e63ed

