### PR TITLE
Fixes for i-vid inputs

### DIFF
--- a/src/pipe/modules/i-vid/conv.comp
+++ b/src/pipe/modules/i-vid/conv.comp
@@ -26,44 +26,55 @@ main()
   float v = texture(img_in[2], (ipos+0.5)/vec2(imageSize(img_out))).r;
 
   vec3 rgb = vec3(0.0);
-  if(params.color == 1)
+  if(params.color == 0 || params.color == 1)
   { // says the ITU-R BT.2087-0
     vec3 YCbCr = vec3(Y,u,v);
-    // D'YCbCr -> E'YCbCr : de-scale range Q_YC
-    //
-    // D'Y  = (219 * E'Y  +  16) * 2^(bits-8)
-    // D'Cb = (224 * E'Cb + 128) * 2^(bits-8)
-    // D'Cr = (224 * E'Cr + 128) * 2^(bits-8)
     if(params.colrange == 0)
-    { // or else it comes to us as full range already
-      if     (params.bits == 0) YCbCr = (YCbCr         - vec3(16.0, 128.0, 128.0 )     )/ vec3(219.0, 224.0, 224.0);
-      else if(params.bits == 1) YCbCr = (YCbCr* 1024.0 - vec3(16.0, 128.0, 128.0)*  4.0)/(vec3(219.0, 224.0, 224.0)*  4.0);
-      else if(params.bits == 2) YCbCr = (YCbCr* 4096.0 - vec3(16.0, 128.0, 128.0)* 16.0)/(vec3(219.0, 224.0, 224.0)* 16.0);
+    {
+      // D'YCbCr -> E'YCbCr : de-scale range Q_YC
+      //
+      // D'Y  = (219 * E'Y  +  16) * 2^(bits-8)
+      // D'Cb = (224 * E'Cb + 128) * 2^(bits-8)
+      // D'Cr = (224 * E'Cr + 128) * 2^(bits-8)
+      if     (params.bits == 0) YCbCr = (YCbCr*  255.0 - vec3(16.0, 128.0, 128.0 )     )/ vec3(219.0, 224.0, 224.0);
+      else if(params.bits == 1) YCbCr = (YCbCr*65535.0 - vec3(16.0, 128.0, 128.0)*  4.0)/(vec3(219.0, 224.0, 224.0)*  4.0);
+      else if(params.bits == 2) YCbCr = (YCbCr*65535.0 - vec3(16.0, 128.0, 128.0)* 16.0)/(vec3(219.0, 224.0, 224.0)* 16.0);
       else if(params.bits == 3) YCbCr = (YCbCr*65535.0 - vec3(16.0, 128.0, 128.0)*256.0)/(vec3(219.0, 224.0, 224.0)*256.0);
     }
-    //
-    // E'YCbCr -> E'RGB   : de-apply the matrix M3
-    //           |  0.2627          0.6780          0.0593        |  |E'R|
-    // E'YCbCr = | -0.2627/1.8814  -0.6780/1.8814   0.5           |  |E'G|
-    //           |  0.5            -0.6780/1.4746  -0.0593/1.4746 |  |E'B|
-    //
-    mat3 M3I = mat3(1, 1, 1,
-        0.0, -0.164553127, 1.8814,
-        1.4746, -0.571353127, 0.0);
-    rgb = M3I * YCbCr;
-    // E'      -> E RGB   : de-apply tone curve (E' = E^(1/2.4)  or E' = E^(1/2))
-    // (we'll use smpte 2084 for this)
-  }
-  else if(params.color == 0)
-  { // rec709, says this guy: https://www.silicondust.com/yuv-to-rgb-conversion-for-tv-video/
-    const mat3 YCbCrToRGBmatrix = mat3(
-        1.1643835616, 0.0000000000, 1.7927410714,
-        1.1643835616, -0.2132486143, -0.5329093286,
-        1.1643835616, 2.1124017857, 0.0000000000);
-    const vec3 YCbCrToRGBzero = vec3(-0.972945075, 0.301482665, -1.133402218);
-    vec3 YCbCr = vec3(Y,u,v);
-    if(params.colrange == 1) YCbCr = (YCbCr*vec3(219.0/255.0, 224.0/255.0, 224.0/255.0) + 16.0/255.0);
-    rgb = YCbCr * YCbCrToRGBmatrix + YCbCrToRGBzero; // convert to full range
+    else if(params.colrange == 1)
+    { // full-range - see Rec. ITU-T H.264 section E.2.1
+      //
+      // D'Y  = E'Y  * (2^bits - 1)
+      // D'Cb = E'Cb * (2^bits - 1) + 2^(bits-1)
+      // D'Cr = E'Cr * (2^bits - 1) + 2^(bits-1)
+      if      (params.bits == 0) YCbCr = YCbCr                - vec3(0.0,   128.0 /  255.0,   128.0 /   255.0);
+      else if (params.bits == 1) YCbCr = YCbCr*65535.0/1023.0 - vec3(0.0,   512.0 / 1023.0,   512.0 /  1023.0);
+      else if (params.bits == 2) YCbCr = YCbCr*65535.0/4095.0 - vec3(0.0,  2048.0 / 4095.0,  2048.0 /  4095.0);
+      else if (params.bits == 3) YCbCr = YCbCr                - vec3(0.0, 32768.0 /65535.0, 32768.0 / 65535.0);
+    }
+    if(params.color == 1)
+    {
+      //
+      // E'YCbCr -> E'RGB   : de-apply the matrix M3
+      //           |  0.2627          0.6780          0.0593        |  |E'R|
+      // E'YCbCr = | -0.2627/1.8814  -0.6780/1.8814   0.5           |  |E'G|
+      //           |  0.5            -0.6780/1.4746  -0.0593/1.4746 |  |E'B|
+      //
+      mat3 M3I = mat3(1, 1, 1,
+          0.0, -0.164553127, 1.8814,
+          1.4746, -0.571353127, 0.0);
+      rgb = M3I * YCbCr;
+      // E'      -> E RGB   : de-apply tone curve (E' = E^(1/2.4)  or E' = E^(1/2))
+      // (we'll use smpte 2084 for this)
+    }
+    else if(params.color == 0)
+    {
+      // E'YCbCr -> E'RGB   : apply the matrix M1
+      mat3 M1 = mat3(1.0, 1.0, 1.0,
+        0.0, -0.0722 * 1.8556 / 0.7152, 1.8556,
+        1.5748, -0.2126 * 1.5748 / 0.7152, 0.0);
+      rgb = M1 * YCbCr;
+    }
   }
 
   if(params.trc == 1)

--- a/src/pipe/modules/i-vid/conv.comp
+++ b/src/pipe/modules/i-vid/conv.comp
@@ -75,11 +75,11 @@ main()
         1.5748, -0.2126 * 1.5748 / 0.7152, 0.0);
       rgb = M1 * YCbCr;
     }
-  }
+      }
 
   if(params.trc == 1)
-  {
-    rgb = mix(pow((rgb+0.055)/(1.0+0.055), vec3(2.4)), rgb/12.92, lessThanEqual(rgb, vec3(0.04045)));
+  { // bt.709
+    rgb = mix(pow((rgb+0.099)/(1.0+0.099), vec3(1.0/0.45)), rgb/4.5, lessThan(rgb, vec3(0.081)));
   }
   else if(params.trc == 2)
   { // undo PQ / SMPTE ST 2084

--- a/src/pipe/modules/i-vid/conv.comp
+++ b/src/pipe/modules/i-vid/conv.comp
@@ -28,7 +28,7 @@ main()
   vec3 rgb = vec3(0.0);
   if(params.color == 0 || params.color == 1)
   { // says the ITU-R BT.2087-0
-    vec3 YCbCr = vec3(Y,u,v);
+    vec3 YCbCr = vec3(Y,u,v) * 65535; // un-normalize back to integer codes
     if(params.colrange == 0)
     {
       // D'YCbCr -> E'YCbCr : de-scale range Q_YC
@@ -36,10 +36,10 @@ main()
       // D'Y  = (219 * E'Y  +  16) * 2^(bits-8)
       // D'Cb = (224 * E'Cb + 128) * 2^(bits-8)
       // D'Cr = (224 * E'Cr + 128) * 2^(bits-8)
-      if     (params.bits == 0) YCbCr = (YCbCr*  255.0 - vec3(16.0, 128.0, 128.0 )     )/ vec3(219.0, 224.0, 224.0);
-      else if(params.bits == 1) YCbCr = (YCbCr*65535.0 - vec3(16.0, 128.0, 128.0)*  4.0)/(vec3(219.0, 224.0, 224.0)*  4.0);
-      else if(params.bits == 2) YCbCr = (YCbCr*65535.0 - vec3(16.0, 128.0, 128.0)* 16.0)/(vec3(219.0, 224.0, 224.0)* 16.0);
-      else if(params.bits == 3) YCbCr = (YCbCr*65535.0 - vec3(16.0, 128.0, 128.0)*256.0)/(vec3(219.0, 224.0, 224.0)*256.0);
+      if     (params.bits == 0) YCbCr = (YCbCr - vec3(16.0, 128.0, 128.0 )     )/ vec3(219.0, 224.0, 224.0);
+      else if(params.bits == 1) YCbCr = (YCbCr - vec3(16.0, 128.0, 128.0)*  4.0)/(vec3(219.0, 224.0, 224.0)*  4.0);
+      else if(params.bits == 2) YCbCr = (YCbCr - vec3(16.0, 128.0, 128.0)* 16.0)/(vec3(219.0, 224.0, 224.0)* 16.0);
+      else if(params.bits == 3) YCbCr = (YCbCr - vec3(16.0, 128.0, 128.0)*256.0)/(vec3(219.0, 224.0, 224.0)*256.0);
     }
     else if(params.colrange == 1)
     { // full-range - see Rec. ITU-T H.264 section E.2.1
@@ -47,10 +47,10 @@ main()
       // D'Y  = E'Y  * (2^bits - 1)
       // D'Cb = E'Cb * (2^bits - 1) + 2^(bits-1)
       // D'Cr = E'Cr * (2^bits - 1) + 2^(bits-1)
-      if      (params.bits == 0) YCbCr = YCbCr                - vec3(0.0,   128.0 /  255.0,   128.0 /   255.0);
-      else if (params.bits == 1) YCbCr = YCbCr*65535.0/1023.0 - vec3(0.0,   512.0 / 1023.0,   512.0 /  1023.0);
-      else if (params.bits == 2) YCbCr = YCbCr*65535.0/4095.0 - vec3(0.0,  2048.0 / 4095.0,  2048.0 /  4095.0);
-      else if (params.bits == 3) YCbCr = YCbCr                - vec3(0.0, 32768.0 /65535.0, 32768.0 / 65535.0);
+      if      (params.bits == 0) YCbCr = YCbCr /   255.0 - vec3(0.0,   128.0 /  255.0,   128.0 /   255.0);
+      else if (params.bits == 1) YCbCr = YCbCr /  1023.0 - vec3(0.0,   512.0 / 1023.0,   512.0 /  1023.0);
+      else if (params.bits == 2) YCbCr = YCbCr /  4095.0 - vec3(0.0,  2048.0 / 4095.0,  2048.0 /  4095.0);
+      else if (params.bits == 3) YCbCr = YCbCr / 65535.0 - vec3(0.0, 32768.0 /65535.0, 32768.0 / 65535.0);
     }
     if(params.color == 1)
     {

--- a/src/pipe/modules/i-vid/main.c
+++ b/src/pipe/modules/i-vid/main.c
@@ -455,8 +455,6 @@ void modify_roi_out(
   // this first needs a robust way of doing frame drops.
   if(mod->graph->frame_rate == 0) // don't overwrite cfg
     mod->graph->frame_rate = frame_rate;
-
-  mod->connector[0].format = d->p_bits > 0 ? dt_token("ui16") : dt_token("ui8");
 }
 
 #if 0 // TODO
@@ -558,7 +556,8 @@ int read_source(
     if(p_bits == 0)
     { // 8-bit
       for(int j=0;j<ht;j++)
-        memcpy(mapped + sizeof(uint8_t) * wd * j, d->vframe->data[p->a] + d->vframe->linesize[p->a]*j, wd);
+        for(int i=0;i<wd;i++)
+          ((uint16_t*)mapped)[wd*j+i] = ((uint8_t*)(d->vframe->data[p->a] + sizeof(uint8_t)*i + d->vframe->linesize[p->a]*j))[0];
     }
     else if(p_bits == 1 || p_bits == 2 || p_bits == 3)
     { // 16-bit
@@ -667,7 +666,7 @@ create_nodes(
       .name   = dt_token("source"),
       .type   = dt_token("source"),
       .chan   = dt_token("y"),
-      .format = d->p_bits ? dt_token("ui16") : dt_token("ui8"),
+      .format = dt_token("ui16"),
       .roi    = module->connector[0].roi,
       .array_length = 3,
       .array_dim    = d->dim,
@@ -687,7 +686,7 @@ create_nodes(
       .name   = dt_token("input"),
       .type   = dt_token("read"),
       .chan   = dt_token("y"),
-      .format = d->p_bits ? dt_token("ui16") : dt_token("ui8"),
+      .format = dt_token("ui16"),
       .roi    = module->connector[0].roi,
       .connected_mi = -1,
       .array_length = 3,

--- a/src/pipe/modules/i-vid/main.c
+++ b/src/pipe/modules/i-vid/main.c
@@ -560,22 +560,10 @@ int read_source(
       for(int j=0;j<ht;j++)
         memcpy(mapped + sizeof(uint8_t) * wd * j, d->vframe->data[p->a] + d->vframe->linesize[p->a]*j, wd);
     }
-    else if(p_bits == 1)
-    { // 10-bit
-      for(int j=0;j<ht;j++)
-        for(int i=0;i<wd;i++)
-          ((uint16_t*)mapped)[wd*j+i] = ((uint16_t*)(d->vframe->data[p->a] + sizeof(uint16_t)*i + d->vframe->linesize[p->a]*j))[0]*64;
-    }
-    else if(p_bits == 2)
-    { // 12-bit
-      for(int j=0;j<ht;j++)
-        for(int i=0;i<wd;i++)
-          ((uint16_t*)mapped)[wd*j+i] = ((uint16_t*)(d->vframe->data[p->a] + sizeof(uint16_t)*i + d->vframe->linesize[p->a]*j))[0]*16;
-    }
-    else if(p_bits == 3)
+    else if(p_bits == 1 || p_bits == 2 || p_bits == 3)
     { // 16-bit
       for(int j=0;j<ht;j++)
-        memcpy(mapped + sizeof(uint16_t) * wd * j, d->vframe->data[p->a] + d->vframe->linesize[p->a]*j, wd);
+        memcpy(mapped + sizeof(uint16_t) * wd * j, d->vframe->data[p->a] + d->vframe->linesize[p->a]*j, wd * sizeof(uint16_t));
     }
   }
 


### PR DESCRIPTION
Based on #92 this adds support for either full-range or limited-range video for any bit depth. It also changes the TRC from sRGB to bt709 when the file metadata indicates bt709. It has not been tested extensively for every possible combination of inputs but seems to work.

This was a useful reference, copies a lot of the formulas from the various ITU docs all in one place: https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.html#_introduction_to_color_conversions

This also uses a ui16 format input to the shader in all cases, even when it shouldn't be necessary because the video input is 8-bit. A version without that change is [here](https://github.com/paolodepetrillo/vkdt/tree/fix-video-color-range). This fixed a weird issue that I was not able to find the root cause of - when using the ui8 input, the histogram shows excessive quantization and there is a loss of shadow detail:
![example_ui8](https://github.com/hanatos/vkdt/assets/3238173/b4f2c0f0-d376-49f3-82b4-2e0fcff9ea3d)
But when putting those exact same 8-bit values in a ui16 buffer, everything looks fine:
![example_ui16](https://github.com/hanatos/vkdt/assets/3238173/e88a7686-23ce-4d85-8a3d-7615c9bf5173)
