### PR TITLE
RFC / WIP - Lens correction

### DIFF
--- a/src/pipe/lens_corr.h
+++ b/src/pipe/lens_corr.h
@@ -1,0 +1,36 @@
+#pragma once
+
+typedef enum dt_lens_corr_type_t
+{
+  s_lens_corr_none = 0,
+  s_lens_corr_dng  = 1
+}
+dt_lens_corr_type_t;
+
+typedef struct dt_warp_rect_coef_t
+{
+  double kr0, kr1, kr2, kr3;
+  double kt0, kt1;
+}
+dt_warp_rect_coef_t;
+
+typedef struct dt_lens_corr_dng_t
+{
+  int                 warp_rect_enabled;
+  dt_warp_rect_coef_t warp_rect_coef[3];
+  double              warp_rect_center_x, warp_rect_center_y;
+}
+dt_lens_corr_dng_t;
+
+typedef union dt_lens_corr_params_t
+{
+  dt_lens_corr_dng_t dng;
+}
+dt_lens_corr_params_t;
+
+typedef struct dt_lens_corr_t
+{
+  dt_lens_corr_type_t   type;
+  dt_lens_corr_params_t params;
+}
+dt_lens_corr_t;

--- a/src/pipe/lens_corr.h
+++ b/src/pipe/lens_corr.h
@@ -16,7 +16,10 @@ dt_warp_rect_coef_t;
 
 typedef struct dt_lens_corr_dng_t
 {
-  int                 warp_rect_enabled;
+  // 0: no WarpRectilinear
+  // 1: warp_rect_coef[0] applies to all planes
+  // 3: separate coefficients for each plane
+  int                 warp_rect_planes;
   dt_warp_rect_coef_t warp_rect_coef[3];
   double              warp_rect_center_x, warp_rect_center_y;
 }

--- a/src/pipe/lens_corr.h
+++ b/src/pipe/lens_corr.h
@@ -16,6 +16,8 @@ dt_warp_rect_coef_t;
 
 typedef struct dt_lens_corr_dng_t
 {
+  int                 active_area[4]; // top, left, bottom, right
+
   // 0: no WarpRectilinear
   // 1: warp_rect_coef[0] applies to all planes
   // 3: separate coefficients for each plane

--- a/src/pipe/module.h
+++ b/src/pipe/module.h
@@ -31,6 +31,7 @@ typedef struct dt_image_params_t
   float    whitebalance[4];   // camera white balance coefficients
   uint32_t filters;           // 0-full 9-xtrans else: bayer bits
   uint32_t crop_aabb[4];      // crops away black borders of raw
+  uint32_t uncropped[2];      // original size of image before any cropping
 
   // basic exif data
   float          cam_to_rec2020[9]; // adobe dng matrix or maybe from exif

--- a/src/pipe/module.h
+++ b/src/pipe/module.h
@@ -16,6 +16,7 @@
 
 #include "global.h"
 #include "connector.h"
+#include "lens_corr.h"
 
 // bare essential meta data that travels
 // with a (raw) input buffer along the graph.
@@ -32,15 +33,16 @@ typedef struct dt_image_params_t
   uint32_t crop_aabb[4];      // crops away black borders of raw
 
   // basic exif data
-  float    cam_to_rec2020[9]; // adobe dng matrix or maybe from exif
-  uint32_t orientation;       // flip/rotate bits from exif
-  char     datetime[20];      // date time string
-  char     maker[32];         // camera maker string
-  char     model[32];         // camera model string
-  float    exposure;          // exposure value as shot
-  float    aperture;          // f-stop as shot
-  float    iso;               // iso value as shot
-  float    focal_length;      // focal length of lens
+  float          cam_to_rec2020[9]; // adobe dng matrix or maybe from exif
+  uint32_t       orientation;       // flip/rotate bits from exif
+  char           datetime[20];      // date time string
+  char           maker[32];         // camera maker string
+  char           model[32];         // camera model string
+  float          exposure;          // exposure value as shot
+  float          aperture;          // f-stop as shot
+  float          iso;               // iso value as shot
+  float          focal_length;      // focal length of lens
+  dt_lens_corr_t lens_corr;         // lens correction parameters
 
   // audio information (from ffmpeg or mlv or game code)
   int snd_format;             // see alsa's snd_pcm_format_t

--- a/src/pipe/module.h
+++ b/src/pipe/module.h
@@ -31,7 +31,6 @@ typedef struct dt_image_params_t
   float    whitebalance[4];   // camera white balance coefficients
   uint32_t filters;           // 0-full 9-xtrans else: bayer bits
   uint32_t crop_aabb[4];      // crops away black borders of raw
-  uint32_t uncropped[2];      // original size of image before any cropping
 
   // basic exif data
   float          cam_to_rec2020[9]; // adobe dng matrix or maybe from exif

--- a/src/pipe/modules/i-raw/dng_opcode.h
+++ b/src/pipe/modules/i-raw/dng_opcode.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "module.h"
+#include "lens_corr.h"
+
+static uint32_t get_be_long(uint8_t **p)
+{
+  uint32_t int_val = ((*p)[0] << 24) | ((*p)[1] << 16) | ((*p)[2] << 8) | (*p)[3];
+  *p += 4;
+  return int_val;
+}
+
+static float get_be_float(uint8_t **p)
+{
+  uint32_t int_val = ((*p)[0] << 24) | ((*p)[1] << 16) | ((*p)[2] << 8) | (*p)[3];
+  float float_val;
+  for(int i = 0; i < 4; i++)
+  {
+    ((char *)&float_val)[i] = ((char *)&int_val)[i];
+  }
+  *p += 4;
+  return float_val;
+}
+
+static double get_be_double(uint8_t **p)
+{
+  uint64_t int_val =
+    ((uint64_t)(*p)[0] << 56) +
+    ((uint64_t)(*p)[1] << 48) +
+    ((uint64_t)(*p)[2] << 40) +
+    ((uint64_t)(*p)[3] << 32) +
+    ((uint64_t)(*p)[4] << 24) +
+    ((uint64_t)(*p)[5] << 16) +
+    ((uint64_t)(*p)[6] << 8) +
+    ((uint64_t)(*p)[7]);
+
+  double double_val;
+  for(int i = 0; i < 8; i++)
+  {
+    ((char *)&double_val)[i] = ((char *)&int_val)[i];
+  }
+  *p += 8;
+  return double_val;
+}
+
+void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_image_params_t *ip)
+{
+  dt_lens_corr_dng_t lc;
+
+  uint8_t *p = buf;
+  uint32_t count = get_be_long(&p);
+  uint32_t offset = 4;
+  while(count > 0)
+  {
+    uint32_t opcode_id = get_be_long(&p);
+    uint32_t spec_ver = get_be_long(&p);
+    uint32_t flags = get_be_long(&p);
+    uint32_t param_size = get_be_long(&p);
+
+    if(offset + 16 + param_size > buf_size)
+    {
+      return; // invalid opcode size
+    }
+
+    if(opcode_id == 1) // WarpRectilinear
+    {
+      uint32_t num_planes = get_be_long(&p);
+      if(num_planes != 1 && num_planes != 3)
+      {
+        continue; // unsupported number of planes
+      }
+      for(int iplane = 0; iplane < num_planes; iplane++)
+      {
+        lc.warp_rect_coef[iplane].kr0 = get_be_double(&p);
+        lc.warp_rect_coef[iplane].kr1 = get_be_double(&p);
+        lc.warp_rect_coef[iplane].kr2 = get_be_double(&p);
+        lc.warp_rect_coef[iplane].kr3 = get_be_double(&p);
+        lc.warp_rect_coef[iplane].kt0 = get_be_double(&p);
+        lc.warp_rect_coef[iplane].kt1 = get_be_double(&p);
+      }
+      if(num_planes == 1)
+      {
+        lc.warp_rect_coef[1] = lc.warp_rect_coef[0];
+        lc.warp_rect_coef[2] = lc.warp_rect_coef[0];
+      }
+      lc.warp_rect_center_x = get_be_double(&p);
+      lc.warp_rect_center_y = get_be_double(&p);
+
+      lc.warp_rect_enabled = true;
+    }
+
+    offset += 16 + param_size;
+    count--;
+  }
+
+  if(lc.warp_rect_enabled)
+  {
+    ip->lens_corr.type = s_lens_corr_dng;
+    ip->lens_corr.params.dng = lc;
+  }
+}

--- a/src/pipe/modules/i-raw/dng_opcode.h
+++ b/src/pipe/modules/i-raw/dng_opcode.h
@@ -81,7 +81,7 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
         lc.warp_rect_coef[iplane].kt1 = get_be_double(&p);
       }
       if(num_planes == 1)
-      {
+      { // only one set of coefs to correct distortion only, not TCA - apply to all planes
         lc.warp_rect_coef[1] = lc.warp_rect_coef[0];
         lc.warp_rect_coef[2] = lc.warp_rect_coef[0];
       }

--- a/src/pipe/modules/i-raw/dng_opcode.h
+++ b/src/pipe/modules/i-raw/dng_opcode.h
@@ -10,6 +10,7 @@ static uint32_t get_be_long(uint8_t **p)
   return int_val;
 }
 
+#if 0
 static float get_be_float(uint8_t **p)
 {
   uint32_t int_val = ((*p)[0] << 24) | ((*p)[1] << 16) | ((*p)[2] << 8) | (*p)[3];
@@ -21,6 +22,7 @@ static float get_be_float(uint8_t **p)
   *p += 4;
   return float_val;
 }
+#endif
 
 static double get_be_double(uint8_t **p)
 {
@@ -53,8 +55,8 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
   while(count > 0)
   {
     uint32_t opcode_id = get_be_long(&p);
-    uint32_t spec_ver = get_be_long(&p);
-    uint32_t flags = get_be_long(&p);
+    get_be_long(&p); // spec version - ignore
+    get_be_long(&p); // flags - ignore
     uint32_t param_size = get_be_long(&p);
 
     if(offset + 16 + param_size > buf_size)

--- a/src/pipe/modules/i-raw/dng_opcode.h
+++ b/src/pipe/modules/i-raw/dng_opcode.h
@@ -47,7 +47,7 @@ static double get_be_double(uint8_t **p)
 
 void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_image_params_t *ip)
 {
-  dt_lens_corr_dng_t lc;
+  dt_lens_corr_dng_t lc = {0};
 
   uint8_t *p = buf;
   uint32_t count = get_be_long(&p);
@@ -80,22 +80,16 @@ void dt_dng_opcode_process_opcode_list_3(uint8_t *buf, uint32_t buf_size, dt_ima
         lc.warp_rect_coef[iplane].kt0 = get_be_double(&p);
         lc.warp_rect_coef[iplane].kt1 = get_be_double(&p);
       }
-      if(num_planes == 1)
-      { // only one set of coefs to correct distortion only, not TCA - apply to all planes
-        lc.warp_rect_coef[1] = lc.warp_rect_coef[0];
-        lc.warp_rect_coef[2] = lc.warp_rect_coef[0];
-      }
       lc.warp_rect_center_x = get_be_double(&p);
       lc.warp_rect_center_y = get_be_double(&p);
-
-      lc.warp_rect_enabled = true;
+      lc.warp_rect_planes = num_planes;
     }
 
     offset += 16 + param_size;
     count--;
   }
 
-  if(lc.warp_rect_enabled)
+  if(lc.warp_rect_planes > 0)
   {
     ip->lens_corr.type = s_lens_corr_dng;
     ip->lens_corr.params.dng = lc;

--- a/src/pipe/modules/i-raw/exif.h
+++ b/src/pipe/modules/i-raw/exif.h
@@ -18,6 +18,7 @@
 
 extern "C" {
 #include "module.h"
+#include "dng_opcode.h"
 }
 
 #include <cassert>
@@ -247,6 +248,22 @@ int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData)
         for(int k=0;k<9;k++)
           ip->cam_to_rec2020[k] = cam_to_rec2020[k];
       }
+    }
+
+    if(FIND_EXIF_TAG("Exif.SubImage1.OpcodeList3"))
+    {
+      uint8_t *data = (uint8_t *)malloc(pos->size());
+      pos->copy(data, Exiv2::invalidByteOrder);
+      dt_dng_opcode_process_opcode_list_3(data, pos->size(), ip);
+      free(data);
+    }
+    else if(FIND_EXIF_TAG("Exif.Image.OpcodeList3"))
+    {
+      // DNGs without an embedded preview have opcodes under Exif.Image
+      uint8_t *data = (uint8_t *)malloc(pos->size());
+      pos->copy(data, Exiv2::invalidByteOrder);
+      dt_dng_opcode_process_opcode_list_3(data, pos->size(), ip);
+      free(data);
     }
     return 0;
   }

--- a/src/pipe/modules/i-raw/exif.h
+++ b/src/pipe/modules/i-raw/exif.h
@@ -265,6 +265,24 @@ int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData)
       dt_dng_opcode_process_opcode_list_3(data, pos->size(), ip);
       free(data);
     }
+
+    if (ip->lens_corr.type == s_lens_corr_dng)
+    {
+      // If applying DNG opcodes, get the ActiveArea, as the opcodes are
+      // intended to apply to that region rather than the DefaultCropOrigin /
+      // DefaultCropSize region.
+      if(FIND_EXIF_TAG("Exif.SubImage1.ActiveArea"))
+      {
+        for (int i=0;i<4;i++)
+          ip->lens_corr.params.dng.active_area[i] = pos->toLong(i);
+      }
+      else if (FIND_EXIF_TAG("Exif.Image.ActiveArea"))
+      {
+        for (int i=0;i<4;i++)
+          ip->lens_corr.params.dng.active_area[i] = pos->toLong(i);
+      }
+    }
+
     return 0;
   }
   catch(Exiv2::AnyError &e)

--- a/src/pipe/modules/i-raw/flat.mk
+++ b/src/pipe/modules/i-raw/flat.mk
@@ -35,7 +35,7 @@ $(RAWSPEED_I)/CMakeLists.txt:
 ifeq ($(VKDT_USE_EXIV2),1)
 MOD_CFLAGS+=$(shell pkg-config --cflags exiv2) -DVKDT_USE_EXIV2=1
 MOD_LDFLAGS+=$(shell pkg-config --libs exiv2)
-pipe/modules/i-raw/libi-raw.so:pipe/modules/i-raw/exif.h
+pipe/modules/i-raw/libi-raw.so:pipe/modules/i-raw/exif.h pipe/modules/i-raw/dng_opcode.h
 endif
 endif # end rawspeed
 

--- a/src/pipe/modules/i-raw/main.c
+++ b/src/pipe/modules/i-raw/main.c
@@ -105,6 +105,8 @@ void modify_roi_out(
   
   if(load_raw(mod, id + graph->frame, filename)) return;
   rawinput_buf_t *mod_data = (rawinput_buf_t *)mod->data;
+  mod->img_param.uncropped[0] = mod_data->img.width;
+  mod->img_param.uncropped[1] = mod_data->img.height;
   // we know we only have one connector called "output" (see our "connectors" file)
   mod->connector[0].roi.full_wd = mod_data->img.width;
   mod->connector[0].roi.full_ht = mod_data->img.height;

--- a/src/pipe/modules/i-raw/main.c
+++ b/src/pipe/modules/i-raw/main.c
@@ -105,8 +105,6 @@ void modify_roi_out(
   
   if(load_raw(mod, id + graph->frame, filename)) return;
   rawinput_buf_t *mod_data = (rawinput_buf_t *)mod->data;
-  mod->img_param.uncropped[0] = mod_data->img.width;
-  mod->img_param.uncropped[1] = mod_data->img.height;
   // we know we only have one connector called "output" (see our "connectors" file)
   mod->connector[0].roi.full_wd = mod_data->img.width;
   mod->connector[0].roi.full_ht = mod_data->img.height;

--- a/src/pipe/modules/i-raw/main.cc
+++ b/src/pipe/modules/i-raw/main.cc
@@ -205,6 +205,8 @@ void modify_roi_out(
   if(load_raw(mod, filename)) return;
   rawinput_buf_t *mod_data = (rawinput_buf_t *)mod->data;
   rawspeed::iPoint2D dim_uncropped = mod_data->d->mRaw->getUncroppedDim();
+  mod->img_param.uncropped[0] = dim_uncropped.x;
+  mod->img_param.uncropped[1] = dim_uncropped.y;
   // we know we only have one connector called "output" (see our "connectors" file)
   mod->connector[0].roi.full_wd = dim_uncropped.x;
   mod->connector[0].roi.full_ht = dim_uncropped.y;

--- a/src/pipe/modules/lenswarp/config.h
+++ b/src/pipe/modules/lenswarp/config.h
@@ -1,0 +1,1 @@
+#define LUT_SIZE 256

--- a/src/pipe/modules/lenswarp/connectors
+++ b/src/pipe/modules/lenswarp/connectors
@@ -1,0 +1,2 @@
+input:read:*:*
+output:write:*:*

--- a/src/pipe/modules/lenswarp/main.c
+++ b/src/pipe/modules/lenswarp/main.c
@@ -1,0 +1,125 @@
+#include "modules/api.h"
+#include "core/log.h"
+#include "config.h"
+
+static void generate_radius_lut_dng(
+    dt_image_params_t *img_param,
+    float             *lut)
+{
+  dt_lens_corr_dng_t *dng = &img_param->lens_corr.params.dng;
+
+  if(dng->warp_rect_coef[0].kt0 != 0 || dng->warp_rect_coef[1].kt1 != 0
+    || dng->warp_rect_coef[0].kt0 != 0 || dng->warp_rect_coef[1].kt1 != 0
+    || dng->warp_rect_coef[0].kt0 != 0 || dng->warp_rect_coef[1].kt1 != 0)
+  {
+    dt_log(s_log_err, "[lenswarp] Ignoring WarpRectilinear tangential coefficients");
+  }
+
+  // For WarpRectilinear, radius 1 is defined as the distance from the center to
+  // the furthest corner of the uncropped image (or ActiveArea?). For the LUT we
+  // want to define radius 1 as the corner of the crop area.
+
+  // pixel location of center in the uncropped image
+  float cx = dng->warp_rect_center_x * img_param->uncropped[0];
+  float cy = dng->warp_rect_center_y * img_param->uncropped[1];
+  // distance to furthest corner of uncropped image
+  float dng_dist = hypotf(
+    MAX(cx, img_param->uncropped[0] - cx),
+    MAX(cy, img_param->uncropped[1] - cy));
+  // distance to furthest corner of cropped image
+  float crop_dist = hypotf(
+    MAX(cx - img_param->crop_aabb[0], img_param->crop_aabb[2] - cx),
+    MAX(cy - img_param->crop_aabb[1], img_param->crop_aabb[3] - cy));
+  float r_scale = crop_dist / dng_dist;
+
+  for(int ch = 0; ch < 3; ch++)
+  {
+    dt_warp_rect_coef_t *c = &dng->warp_rect_coef[ch];
+    for(int i = 0; i < LUT_SIZE; i++)
+    {
+      float r = (float)i / (LUT_SIZE - 1); // radius in the undistorted output image
+      float rs2 = r * r * r_scale;
+      lut[i * 4 + ch] = c->kr0 + rs2 * (c->kr1 + rs2 * (c->kr2 + rs2 * c->kr3));
+    }
+  }
+}
+
+static void get_center_dng(
+    dt_image_params_t *img_param,
+    float             *center)
+{
+  // TODO this might actually be relative to the ActiveArea not the full uncropped area?
+
+  dt_lens_corr_dng_t *dng = &img_param->lens_corr.params.dng;
+  // pixel location of center in the uncropped image
+  float cx = dng->warp_rect_center_x * img_param->uncropped[0];
+  float cy = dng->warp_rect_center_y * img_param->uncropped[1];
+  // pixel location of center in the cropped image
+  cx -= img_param->crop_aabb[0];
+  cy -= img_param->crop_aabb[1];
+  // location of center as fraction of the cropped image size
+  cx /= (img_param->crop_aabb[2] - img_param->crop_aabb[0]);
+  cy /= (img_param->crop_aabb[3] - img_param->crop_aabb[1]);
+  center[0] = cx;
+  center[1] = cy;
+}
+
+int read_source(
+    dt_module_t             *mod,
+    void                    *mapped,
+    dt_read_source_params_t *p)
+{
+  switch(mod->img_param.lens_corr.type)
+  {
+    case s_lens_corr_dng:
+      generate_radius_lut_dng(&mod->img_param, (float *)mapped);
+      break;
+    default:
+      break;
+  }
+  return 0;
+}
+
+void commit_params(dt_graph_t *graph, dt_module_t *mod)
+{
+  float *f = (float *)mod->committed_param;
+  switch(mod->img_param.lens_corr.type)
+  {
+    case s_lens_corr_dng:
+      get_center_dng(&mod->img_param, &f[0]);
+      break;
+    default:
+      f[0] = -1; // no-op
+      break;
+  }
+
+  const float scale  = dt_module_param_float(mod, dt_module_get_param(mod->so, dt_token("scale")))[0];
+  f[2] = scale;
+}
+
+int init(dt_module_t *mod)
+{
+  mod->committed_param_size = sizeof(float)*(3);
+  return 0;
+}
+
+void create_nodes(
+    dt_graph_t  *graph,
+    dt_module_t *module)
+{
+  dt_roi_t lutroi = (dt_roi_t){ .wd = LUT_SIZE, .ht = 1 };
+  const int id_radlut = dt_node_add(graph, module, "radlut", "source",
+    LUT_SIZE, 1, 1, 0, 0, 1,
+    "source", "source", "rgba", "f32", &lutroi);
+
+  const int id_main = dt_node_add(graph, module, "lenswarp", "main",
+    module->connector[0].roi.wd, module->connector[0].roi.ht, 1,
+    0, 0, 3,
+    "input",  "read",  "rgba", "f16", &module->connector[0].roi,
+    "output", "write", "rgba", "f16", &module->connector[0].roi,
+    "radlut", "read",  "rgba", "f32", &lutroi);
+
+  CONN(dt_node_connect(graph, id_radlut, 0, id_main, 2));
+  dt_connector_copy(graph, module, 0, id_main, 0);
+  dt_connector_copy(graph, module, 1, id_main, 1);
+}

--- a/src/pipe/modules/lenswarp/main.c
+++ b/src/pipe/modules/lenswarp/main.c
@@ -16,16 +16,16 @@ static void generate_radius_lut_dng(
   }
 
   // For WarpRectilinear, radius 1 is defined as the distance from the center to
-  // the furthest corner of the uncropped image (or ActiveArea?). For the LUT we
-  // want to define radius 1 as the corner of the crop area.
+  // the furthest corner of the ActiveArea. For the LUT we want to define radius
+  // 1 as the corner of the crop area.
 
-  // pixel location of center in the uncropped image
-  float cx = dng->warp_rect_center_x * img_param->uncropped[0];
-  float cy = dng->warp_rect_center_y * img_param->uncropped[1];
-  // distance to furthest corner of uncropped image
+  // pixel location of center in the uncropped ActiveArea
+  float cx = dng->warp_rect_center_x * (dng->active_area[3] - dng->active_area[1]);
+  float cy = dng->warp_rect_center_y * (dng->active_area[2] - dng->active_area[0]);
+  // distance to furthest corner of uncropped ActiveArea
   float dng_dist = hypotf(
-    MAX(cx, img_param->uncropped[0] - cx),
-    MAX(cy, img_param->uncropped[1] - cy));
+    MAX(cx, (dng->active_area[3] - dng->active_area[1]) - cx),
+    MAX(cy, (dng->active_area[2] - dng->active_area[0]) - cy));
   // distance to furthest corner of cropped image
   float crop_dist = hypotf(
     MAX(cx - img_param->crop_aabb[0], img_param->crop_aabb[2] - cx),
@@ -48,12 +48,10 @@ static void get_center_dng(
     dt_image_params_t *img_param,
     float             *center)
 {
-  // TODO this might actually be relative to the ActiveArea not the full uncropped area?
-
   dt_lens_corr_dng_t *dng = &img_param->lens_corr.params.dng;
-  // pixel location of center in the uncropped image
-  float cx = dng->warp_rect_center_x * img_param->uncropped[0];
-  float cy = dng->warp_rect_center_y * img_param->uncropped[1];
+  // pixel location of center in the uncropped ActiveArea
+  float cx = dng->warp_rect_center_x * (dng->active_area[3] - dng->active_area[1]);
+  float cy = dng->warp_rect_center_y * (dng->active_area[2] - dng->active_area[0]);
   // pixel location of center in the cropped image
   cx -= img_param->crop_aabb[0];
   cy -= img_param->crop_aabb[1];

--- a/src/pipe/modules/lenswarp/main.comp
+++ b/src/pipe/modules/lenswarp/main.comp
@@ -49,5 +49,12 @@ main()
   float sample_r = sample_catmull_rom(img_in, p_in_r).r;
   float sample_g = sample_catmull_rom(img_in, p_in_g).g;
   float sample_b = sample_catmull_rom(img_in, p_in_b).b;
-  imageStore(img_out, ipos, vec4(sample_r, sample_g, sample_b, 0));
+  if(any(lessThan(p_in_g, vec2(0, 0))) || any(greaterThan(p_in_g, vec2(1, 1))))
+  { // black border for pixels outside the input image
+    imageStore(img_out, ipos, vec4(0, 0, 0, 0));
+  }
+  else
+  {
+    imageStore(img_out, ipos, vec4(sample_r, sample_g, sample_b, 0));
+  }
 }

--- a/src/pipe/modules/lenswarp/main.comp
+++ b/src/pipe/modules/lenswarp/main.comp
@@ -1,0 +1,53 @@
+#version 460
+#extension GL_GOOGLE_include_directive    : enable
+
+#include "shared.glsl"
+#include "config.h"
+
+layout(local_size_x = DT_LOCAL_SIZE_X, local_size_y = DT_LOCAL_SIZE_Y, local_size_z = 1) in;
+
+layout(std140, set = 0, binding = 1) uniform params_t
+{
+  vec2 center;
+  float scale;
+} params;
+
+layout( // input f16 buffer rgb
+    set = 1, binding = 0
+) uniform sampler2D img_in;
+
+layout( // output f16 buffer rgb
+    set = 1, binding = 1
+) uniform writeonly image2D img_out;
+
+layout( // radius LUT
+  set = 1, binding = 2
+) uniform sampler2D radlut_in;
+
+void
+main()
+{
+  ivec2 ipos = ivec2(gl_GlobalInvocationID);
+  if(any(greaterThanEqual(ipos, imageSize(img_out)))) return;
+  if(params.center.x < 0)
+  { // no-op
+    imageStore(img_out, ipos, texelFetch(img_in, ipos, 0));
+    return;
+  }
+
+  // max radius is the distance in pixels from the center to the furthest corner of the image
+  vec2 px_size = imageSize(img_out);
+  vec2 furthest = vec2(max(params.center.x, 1-params.center.x), max(params.center.y, 1-params.center.y));
+  float rad_max = length(px_size * furthest);
+  float rad_out = params.scale * distance(ipos, px_size * params.center) / rad_max;
+  vec4 rad_scale = texture(radlut_in, vec2(rad_out * ((LUT_SIZE-1.0)/LUT_SIZE) + (1.0/LUT_SIZE), 0.5));
+
+  vec2 p_out = (ipos+0.5)/px_size;
+  vec2 p_in_r = params.scale * (p_out - params.center) * rad_scale.r + params.center;
+  vec2 p_in_g = params.scale * (p_out - params.center) * rad_scale.g + params.center;
+  vec2 p_in_b = params.scale * (p_out - params.center) * rad_scale.b + params.center;
+  float sample_r = sample_catmull_rom(img_in, p_in_r).r;
+  float sample_g = sample_catmull_rom(img_in, p_in_g).g;
+  float sample_b = sample_catmull_rom(img_in, p_in_b).b;
+  imageStore(img_out, ipos, vec4(sample_r, sample_g, sample_b, 0));
+}

--- a/src/pipe/modules/lenswarp/main.comp
+++ b/src/pipe/modules/lenswarp/main.comp
@@ -10,6 +10,7 @@ layout(std140, set = 0, binding = 1) uniform params_t
 {
   vec2 center;
   float scale;
+  uint planes;
 } params;
 
 layout( // input f16 buffer rgb
@@ -29,7 +30,7 @@ main()
 {
   ivec2 ipos = ivec2(gl_GlobalInvocationID);
   if(any(greaterThanEqual(ipos, imageSize(img_out)))) return;
-  if(params.center.x < 0)
+  if(params.planes == 0)
   { // no-op
     imageStore(img_out, ipos, texelFetch(img_in, ipos, 0));
     return;
@@ -43,18 +44,34 @@ main()
   vec4 rad_scale = texture(radlut_in, vec2(rad_out * ((LUT_SIZE-1.0)/LUT_SIZE) + (1.0/LUT_SIZE), 0.5));
 
   vec2 p_out = (ipos+0.5)/px_size;
-  vec2 p_in_r = params.scale * (p_out - params.center) * rad_scale.r + params.center;
-  vec2 p_in_g = params.scale * (p_out - params.center) * rad_scale.g + params.center;
-  vec2 p_in_b = params.scale * (p_out - params.center) * rad_scale.b + params.center;
-  float sample_r = sample_catmull_rom(img_in, p_in_r).r;
-  float sample_g = sample_catmull_rom(img_in, p_in_g).g;
-  float sample_b = sample_catmull_rom(img_in, p_in_b).b;
-  if(any(lessThan(p_in_g, vec2(0, 0))) || any(greaterThan(p_in_g, vec2(1, 1))))
-  { // black border for pixels outside the input image
-    imageStore(img_out, ipos, vec4(0, 0, 0, 0));
+  if(params.planes == 1)
+  { // apply same correction to all planes
+    vec2 p_in = params.scale * (p_out - params.center) * rad_scale.r + params.center;
+    vec4 sample_rgb = sample_catmull_rom(img_in, p_in);
+    if(any(lessThan(p_in, vec2(0, 0))) || any(greaterThan(p_in, vec2(1, 1))))
+    { // black border for pixels outside the input image
+      imageStore(img_out, ipos, vec4(0, 0, 0, 0));
+    }
+    else
+    {
+      imageStore(img_out, ipos, sample_rgb);
+    }
   }
   else
-  {
-    imageStore(img_out, ipos, vec4(sample_r, sample_g, sample_b, 0));
+  { // apply separate correction to each plane
+    vec2 p_in_r = params.scale * (p_out - params.center) * rad_scale.r + params.center;
+    vec2 p_in_g = params.scale * (p_out - params.center) * rad_scale.g + params.center;
+    vec2 p_in_b = params.scale * (p_out - params.center) * rad_scale.b + params.center;
+    float sample_r = sample_catmull_rom(img_in, p_in_r).r;
+    float sample_g = sample_catmull_rom(img_in, p_in_g).g;
+    float sample_b = sample_catmull_rom(img_in, p_in_b).b;
+    if(any(lessThan(p_in_g, vec2(0, 0))) || any(greaterThan(p_in_g, vec2(1, 1))))
+    { // black border for pixels outside the input image
+      imageStore(img_out, ipos, vec4(0, 0, 0, 0));
+    }
+    else
+    {
+      imageStore(img_out, ipos, vec4(sample_r, sample_g, sample_b, 0));
+    }
   }
 }

--- a/src/pipe/modules/lenswarp/params
+++ b/src/pipe/modules/lenswarp/params
@@ -1,0 +1,1 @@
+scale:float:1:1.0

--- a/src/pipe/modules/lenswarp/params.ui
+++ b/src/pipe/modules/lenswarp/params.ui
@@ -1,0 +1,1 @@
+scale:slider:0.75:1.25

--- a/src/pipe/modules/lenswarp/readme.md
+++ b/src/pipe/modules/lenswarp/readme.md
@@ -1,1 +1,20 @@
 # lenswarp: correct for lens distortion and TCA
+
+This warps the image in order to correct for lens distortion and / or transverse chromatic aberration.
+
+The correction parameters are automatically obtained from:
+
+* for [DNG](https://helpx.adobe.com/camera-raw/digital-negative.html) files: the `WarpRectilinear` opcode in the `OpcodeList3` tag
+
+If there are no supported correction parameters embedded in the file, this module does nothing.
+
+In some cases the correction may result in black areas visible around the edges of the image, or more of the image being cropped away than is strictly necessary to avoid black areas. This can be corrected by adjusting the `scale` parameter. Regardless of the `scale` setting, the output is always the exact same size as the input.
+
+## connectors
+
+* `input` the input image
+* `output` the output image after applying correction
+
+## parameters
+
+* `scale` scale the image larger or smaller

--- a/src/pipe/modules/lenswarp/readme.md
+++ b/src/pipe/modules/lenswarp/readme.md
@@ -1,0 +1,1 @@
+# lenswarp: correct for lens distortion and TCA

--- a/src/pipe/modules/lenswarp/readme.md
+++ b/src/pipe/modules/lenswarp/readme.md
@@ -2,6 +2,8 @@
 
 This warps the image in order to correct for lens distortion and / or transverse chromatic aberration.
 
+This must be placed after demosaic and before crop for correct operation.
+
 The correction parameters are automatically obtained from:
 
 * for [DNG](https://helpx.adobe.com/camera-raw/digital-negative.html) files: the `WarpRectilinear` opcode in the `OpcodeList3` tag


### PR DESCRIPTION
I have been experimenting with a lens correction module which uses a LUT to map a radius in the output image to a radius in the input image, rather than any specific distortion model, to correct for distortion and / or TCA.

This first attempt only supports the WarpRectilinear opcode embedded in DNG file metadata - I figured this was a good starting point since it's [openly documented](https://helpx.adobe.com/content/dam/help/en/photoshop/pdf/DNG_Spec_1_7_0_0.pdf) rather than being reverse engineered from proprietary tags. It could also easily be extended to support lensfun models, probably without any change to the shader kernel.

I have mostly been testing this with Olympus .orf's converted through Adobe DNG Converter - it reads the proprietary embedded correction and converts to WarpRectilinear.

There is a slight difference from the behavior of the darktable implementation: the correction results in a non-rectangular image with irregular black edges, and darktable automatically finds the largest rectangle inscribed in that image and sets the scale to crop to that rectangle and hide those black edges. This may be needed for some other models like lensfun, but DNG WarpRectilinear typically has the correct scaling implicit in the coefficients already so I don't try to do any auto scaling. The scale slider is provided to override if necessary.

Possible TODOs:

- Support rawloader in addition to rawspeed+exiv2 (Would need to modify rawloader to make the necessary exif tags available)
- Lensfun models
- Correction for Sony and Fuji raws [as in darktable](https://github.com/darktable-org/darktable/blob/master/src/iop/lens.cc) and Olympus [as in this darktable pr](https://github.com/darktable-org/darktable/pull/12760)
- Apply tangential coefficients in WarpRectilinear, although I've never seen a file where they were nonzero
- Support other DNG tags WarpRectilinear2 and WarpFisheye
- Option to apply only distortion, only TCA, or both (not possible for DNG but should be otherwise)