### PR TITLE
WIP / RFC - DNG opcode list processing

### DIFF
--- a/src/pipe/dng_opcode.c
+++ b/src/pipe/dng_opcode.c
@@ -51,7 +51,7 @@ get_be_double(uint8_t **p)
 }
 
 static void
-decode_dng_region(dng_region_t *region, uint8_t **p)
+decode_dng_region(dt_dng_region_t *region, uint8_t **p)
 {
   region->top       = get_be_long(p);
   region->left      = get_be_long(p);
@@ -69,9 +69,9 @@ decode_warp_rectilinear(void **out, uint8_t **p, uint32_t len)
   uint32_t count = get_be_long(p);
   if(len != 20 + count * 48)
     return 1;
-  dng_warp_rectilinear_t *wr =
-      calloc(1, sizeof(dng_warp_rectilinear_t) +
-                    count * sizeof(dng_warp_rectilinear_coef_t));
+  dt_dng_warp_rectilinear_t *wr =
+      calloc(1, sizeof(dt_dng_warp_rectilinear_t) +
+                    count * sizeof(dt_dng_warp_rectilinear_coef_t));
   *out      = wr;
   wr->count = count;
   for(int i = 0; i < count; i++)
@@ -92,8 +92,8 @@ decode_warp_fisheye(void **out, uint8_t **p, uint32_t len)
   uint32_t count = get_be_long(p);
   if(len != 20 + count * 32)
     return 1;
-  dng_warp_fisheye_t *wr = calloc(
-      1, sizeof(dng_warp_fisheye_t) + count * sizeof(dng_warp_fisheye_coef_t));
+  dt_dng_warp_fisheye_t *wr = calloc(
+      1, sizeof(dt_dng_warp_fisheye_t) + count * sizeof(dt_dng_warp_fisheye_coef_t));
   *out      = wr;
   wr->count = count;
   for(int i = 0; i < count; i++)
@@ -109,7 +109,7 @@ decode_warp_fisheye(void **out, uint8_t **p, uint32_t len)
 static int
 decode_gain_map(void **out, uint8_t **p, uint32_t len)
 {
-  dng_gain_map_t gm;
+  dt_dng_gain_map_t gm;
   decode_dng_region(&gm.region, p);
   gm.map_points_v  = get_be_long(p);
   gm.map_points_h  = get_be_long(p);
@@ -122,9 +122,9 @@ decode_gain_map(void **out, uint8_t **p, uint32_t len)
   size_t count = gm.map_points_h * gm.map_points_v * gm.map_planes;
   if(len != 76 + count * sizeof(float))
     return 1;
-  dng_gain_map_t *pgm =
-      calloc(1, sizeof(dng_gain_map_t) + count * sizeof(float));
-  memcpy(pgm, &gm, sizeof(dng_gain_map_t));
+  dt_dng_gain_map_t *pgm =
+      calloc(1, sizeof(dt_dng_gain_map_t) + count * sizeof(float));
+  memcpy(pgm, &gm, sizeof(dt_dng_gain_map_t));
   *out = pgm;
   for(int i = 0; i < count; i++)
     pgm->map_gain[i] = get_be_float(p);
@@ -137,7 +137,7 @@ decode_fix_vignette_radial(void **out, uint8_t **p, uint32_t len)
 {
   if(len != 56)
     return 1;
-  dng_fix_vignette_radial_t *fvr = calloc(1, sizeof(dng_fix_vignette_radial_t));
+  dt_dng_fix_vignette_radial_t *fvr = calloc(1, sizeof(dt_dng_fix_vignette_radial_t));
   *out                           = fvr;
   for(int j = 0; j < 5; j++)
     fvr->k[j] = get_be_double(p);
@@ -151,8 +151,8 @@ decode_fix_bad_pixels_constant(void **out, uint8_t **p, uint32_t len)
 {
   if(len != 8)
     return 1;
-  dng_fix_bad_pixels_constant_t *fbpc =
-      calloc(1, sizeof(dng_fix_bad_pixels_constant_t));
+  dt_dng_fix_bad_pixels_constant_t *fbpc =
+      calloc(1, sizeof(dt_dng_fix_bad_pixels_constant_t));
   *out              = fbpc;
   fbpc->constant    = get_be_long(p);
   fbpc->bayer_phase = get_be_long(p);
@@ -167,8 +167,8 @@ decode_fix_bad_pixels_list(void **out, uint8_t **p, uint32_t len)
   uint32_t bad_rect_count  = get_be_long(p);
   if(len != 12 + bad_point_count * 8 + bad_rect_count * 16)
     return 1;
-  dng_fix_bad_pixels_list_t *fbpl = calloc(
-      1, sizeof(dng_fix_bad_pixels_list_t) +
+  dt_dng_fix_bad_pixels_list_t *fbpl = calloc(
+      1, sizeof(dt_dng_fix_bad_pixels_list_t) +
              (bad_point_count * 2 + bad_rect_count * 4) * sizeof(uint32_t));
   *out                  = fbpl;
   fbpl->bayer_phase     = bayer_phase;
@@ -186,7 +186,7 @@ decode_trim_bounds(void **out, uint8_t **p, uint32_t len)
 {
   if(len != 16)
     return 1;
-  dng_trim_bounds_t *tb = calloc(1, sizeof(dng_trim_bounds_t));
+  dt_dng_trim_bounds_t *tb = calloc(1, sizeof(dt_dng_trim_bounds_t));
   *out                  = tb;
   tb->top               = get_be_long(p);
   tb->left              = get_be_long(p);
@@ -198,15 +198,15 @@ decode_trim_bounds(void **out, uint8_t **p, uint32_t len)
 static int
 decode_map_table(void **out, uint8_t **p, uint32_t len)
 {
-  dng_map_table_t mt;
+  dt_dng_map_table_t mt;
   decode_dng_region(&mt.region, p);
   mt.table_size = get_be_long(p);
   if(len != 36 + 2 * mt.table_size)
     return 1;
-  dng_map_table_t *pmt =
-      calloc(1, sizeof(dng_map_table_t) + mt.table_size * sizeof(uint16_t));
+  dt_dng_map_table_t *pmt =
+      calloc(1, sizeof(dt_dng_map_table_t) + mt.table_size * sizeof(uint16_t));
   *out = pmt;
-  memcpy(pmt, &mt, sizeof(dng_map_table_t));
+  memcpy(pmt, &mt, sizeof(dt_dng_map_table_t));
   for(int i = 0; i < mt.table_size; i++)
     pmt->table[i] = get_be_short(p);
   return 0;
@@ -215,15 +215,15 @@ decode_map_table(void **out, uint8_t **p, uint32_t len)
 static int
 decode_map_polynomial(void **out, uint8_t **p, uint32_t len)
 {
-  dng_map_polynomial_t mp;
+  dt_dng_map_polynomial_t mp;
   decode_dng_region(&mp.region, p);
   mp.degree = get_be_long(p);
   if(len != 36 + 8 * mp.degree)
     return 1;
-  dng_map_polynomial_t *pmp =
-      calloc(1, sizeof(dng_map_polynomial_t) + mp.degree * sizeof(double));
+  dt_dng_map_polynomial_t *pmp =
+      calloc(1, sizeof(dt_dng_map_polynomial_t) + mp.degree * sizeof(double));
   *out = pmp;
-  memcpy(pmp, &mp, sizeof(dng_map_polynomial_t));
+  memcpy(pmp, &mp, sizeof(dt_dng_map_polynomial_t));
   for(int i = 0; i < mp.degree; i++)
     pmp->coefs[i] = get_be_double(p);
   return 0;
@@ -235,9 +235,9 @@ decode_warp_rectilinear_2(void **out, uint8_t **p, uint32_t len)
   uint32_t count = get_be_long(p);
   if(len != 24 + count * 76)
     return 1;
-  dng_warp_rectilinear_2_t *wr =
-      calloc(1, sizeof(dng_warp_rectilinear_2_t) +
-                    count * sizeof(dng_warp_rectilinear_2_coef_t));
+  dt_dng_warp_rectilinear_2_t *wr =
+      calloc(1, sizeof(dt_dng_warp_rectilinear_2_t) +
+                    count * sizeof(dt_dng_warp_rectilinear_2_coef_t));
   *out      = wr;
   wr->count = count;
   for(int i = 0; i < count; i++)
@@ -256,7 +256,7 @@ decode_warp_rectilinear_2(void **out, uint8_t **p, uint32_t len)
 }
 
 static int
-decode_opcode(dng_opcode_t *op, uint8_t **p)
+decode_opcode(dt_dng_opcode_t *op, uint8_t **p)
 {
   uint32_t op_id = get_be_long(p);
   get_be_long(p);
@@ -296,7 +296,7 @@ decode_opcode(dng_opcode_t *op, uint8_t **p)
   }
 }
 
-dng_opcode_list_t *
+dt_dng_opcode_list_t *
 dt_dng_opcode_list_decode(uint8_t *data, size_t len)
 {
   uint8_t *p     = data;
@@ -316,8 +316,8 @@ dt_dng_opcode_list_decode(uint8_t *data, size_t len)
   if(p != &data[len])
     return NULL;
 
-  dng_opcode_list_t *ops =
-      calloc(1, sizeof(dng_opcode_list_t) + count * sizeof(dng_opcode_t));
+  dt_dng_opcode_list_t *ops =
+      calloc(1, sizeof(dt_dng_opcode_list_t) + count * sizeof(dt_dng_opcode_t));
   ops->count = count;
 
   p = &data[4];
@@ -334,7 +334,7 @@ dt_dng_opcode_list_decode(uint8_t *data, size_t len)
 }
 
 void
-dt_dng_opcode_list_free(dng_opcode_list_t *ops)
+dt_dng_opcode_list_free(dt_dng_opcode_list_t *ops)
 {
   if(ops == NULL)
     return;

--- a/src/pipe/dng_opcode.c
+++ b/src/pipe/dng_opcode.c
@@ -318,6 +318,7 @@ dt_dng_opcode_list_decode(uint8_t *data, size_t len)
 
   dng_opcode_list_t *ops =
       calloc(1, sizeof(dng_opcode_list_t) + count * sizeof(dng_opcode_t));
+  ops->count = count;
 
   p = &data[4];
   for(int i = 0; i < count; i++)

--- a/src/pipe/dng_opcode.c
+++ b/src/pipe/dng_opcode.c
@@ -1,0 +1,339 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dng_opcode.h"
+
+static uint16_t
+get_be_short(uint8_t **p)
+{
+  uint16_t short_val = ((*p)[0] << 8) | (*p)[1];
+  *p += 2;
+  return short_val;
+}
+
+static uint32_t
+get_be_long(uint8_t **p)
+{
+  uint32_t int_val =
+      ((*p)[0] << 24) | ((*p)[1] << 16) | ((*p)[2] << 8) | (*p)[3];
+  *p += 4;
+  return int_val;
+}
+
+static float
+get_be_float(uint8_t **p)
+{
+  uint32_t int_val =
+      ((*p)[0] << 24) | ((*p)[1] << 16) | ((*p)[2] << 8) | (*p)[3];
+  float float_val;
+  for(int i = 0; i < 4; i++)
+  {
+    ((char *)&float_val)[i] = ((char *)&int_val)[i];
+  }
+  *p += 4;
+  return float_val;
+}
+
+static double
+get_be_double(uint8_t **p)
+{
+  uint64_t int_val = ((uint64_t)(*p)[0] << 56) + ((uint64_t)(*p)[1] << 48) +
+                     ((uint64_t)(*p)[2] << 40) + ((uint64_t)(*p)[3] << 32) +
+                     ((uint64_t)(*p)[4] << 24) + ((uint64_t)(*p)[5] << 16) +
+                     ((uint64_t)(*p)[6] << 8) + ((uint64_t)(*p)[7]);
+
+  double double_val;
+  for(int i = 0; i < 8; i++)
+    ((char *)&double_val)[i] = ((char *)&int_val)[i];
+  *p += 8;
+  return double_val;
+}
+
+static void
+decode_dng_region(dng_region_t *region, uint8_t **p)
+{
+  region->top       = get_be_long(p);
+  region->left      = get_be_long(p);
+  region->bottom    = get_be_long(p);
+  region->right     = get_be_long(p);
+  region->plane     = get_be_long(p);
+  region->planes    = get_be_long(p);
+  region->row_pitch = get_be_long(p);
+  region->col_pitch = get_be_long(p);
+}
+
+static int
+decode_warp_rectilinear(void **out, uint8_t **p, uint32_t len)
+{
+  uint32_t count = get_be_long(p);
+  if(len != 20 + count * 48)
+    return 1;
+  dng_warp_rectilinear_t *wr =
+      calloc(1, sizeof(dng_warp_rectilinear_t) +
+                    count * sizeof(dng_warp_rectilinear_coef_t));
+  *out      = wr;
+  wr->count = count;
+  for(int i = 0; i < count; i++)
+  {
+    for(int j = 0; j < 4; j++)
+      wr->coefs[i].kr[j] = get_be_double(p);
+    for(int j = 0; j < 2; j++)
+      wr->coefs[i].kt[j] = get_be_double(p);
+  }
+  wr->center_x = get_be_double(p);
+  wr->center_y = get_be_double(p);
+  return 0;
+}
+
+static int
+decode_warp_fisheye(void **out, uint8_t **p, uint32_t len)
+{
+  uint32_t count = get_be_long(p);
+  if(len != 20 + count * 32)
+    return 1;
+  dng_warp_fisheye_t *wr = calloc(
+      1, sizeof(dng_warp_fisheye_t) + count * sizeof(dng_warp_fisheye_coef_t));
+  *out      = wr;
+  wr->count = count;
+  for(int i = 0; i < count; i++)
+  {
+    for(int j = 0; j < 4; j++)
+      wr->coefs[i].kr[j] = get_be_double(p);
+  }
+  wr->center_x = get_be_double(p);
+  wr->center_y = get_be_double(p);
+  return 0;
+}
+
+static int
+decode_gain_map(void **out, uint8_t **p, uint32_t len)
+{
+  dng_gain_map_t gm;
+  decode_dng_region(&gm.region, p);
+  gm.map_points_v  = get_be_long(p);
+  gm.map_points_h  = get_be_long(p);
+  gm.map_spacing_v = get_be_double(p);
+  gm.map_spacing_h = get_be_double(p);
+  gm.map_origin_v  = get_be_double(p);
+  gm.map_origin_h  = get_be_double(p);
+  gm.map_planes    = get_be_long(p);
+
+  size_t count = gm.map_points_h * gm.map_points_v * gm.map_planes;
+  if(len != 76 + count * sizeof(float))
+    return 1;
+  dng_gain_map_t *pgm =
+      calloc(1, sizeof(dng_gain_map_t) + count * sizeof(float));
+  memcpy(pgm, &gm, sizeof(dng_gain_map_t));
+  *out = pgm;
+  for(int i = 0; i < count; i++)
+    pgm->map_gain[i] = get_be_float(p);
+
+  return 0;
+}
+
+static int
+decode_fix_vignette_radial(void **out, uint8_t **p, uint32_t len)
+{
+  if(len != 56)
+    return 1;
+  dng_fix_vignette_radial_t *fvr = calloc(1, sizeof(dng_fix_vignette_radial_t));
+  *out                           = fvr;
+  for(int j = 0; j < 5; j++)
+    fvr->k[j] = get_be_double(p);
+  fvr->center_x = get_be_double(p);
+  fvr->center_y = get_be_double(p);
+  return 0;
+}
+
+static int
+decode_fix_bad_pixels_constant(void **out, uint8_t **p, uint32_t len)
+{
+  if(len != 8)
+    return 1;
+  dng_fix_bad_pixels_constant_t *fbpc =
+      calloc(1, sizeof(dng_fix_bad_pixels_constant_t));
+  *out              = fbpc;
+  fbpc->constant    = get_be_long(p);
+  fbpc->bayer_phase = get_be_long(p);
+  return 0;
+}
+
+static int
+decode_fix_bad_pixels_list(void **out, uint8_t **p, uint32_t len)
+{
+  uint32_t bayer_phase     = get_be_long(p);
+  uint32_t bad_point_count = get_be_long(p);
+  uint32_t bad_rect_count  = get_be_long(p);
+  if(len != 12 + bad_point_count * 8 + bad_rect_count * 16)
+    return 1;
+  dng_fix_bad_pixels_list_t *fbpl = calloc(
+      1, sizeof(dng_fix_bad_pixels_list_t) +
+             (bad_point_count * 2 + bad_rect_count * 4) * sizeof(uint32_t));
+  *out                  = fbpl;
+  fbpl->bayer_phase     = bayer_phase;
+  fbpl->bad_point_count = bad_point_count;
+  fbpl->bad_rect_count  = bad_rect_count;
+  fbpl->points          = &fbpl->_data[0];
+  fbpl->rects           = &fbpl->_data[bad_point_count * 2];
+  for(int i = 0; i < 2 * bad_point_count + 4 * bad_rect_count; i++)
+    fbpl->_data[i] = get_be_long(p);
+  return 0;
+}
+
+static int
+decode_trim_bounds(void **out, uint8_t **p, uint32_t len)
+{
+  if(len != 16)
+    return 1;
+  dng_trim_bounds_t *tb = calloc(1, sizeof(dng_trim_bounds_t));
+  *out                  = tb;
+  tb->top               = get_be_long(p);
+  tb->left              = get_be_long(p);
+  tb->bottom            = get_be_long(p);
+  tb->right             = get_be_long(p);
+  return 0;
+}
+
+static int
+decode_map_table(void **out, uint8_t **p, uint32_t len)
+{
+  dng_map_table_t mt;
+  decode_dng_region(&mt.region, p);
+  mt.table_size = get_be_long(p);
+  if(len != 36 + 2 * mt.table_size)
+    return 1;
+  dng_map_table_t *pmt =
+      calloc(1, sizeof(dng_map_table_t) + mt.table_size * sizeof(uint16_t));
+  *out = pmt;
+  memcpy(pmt, &mt, sizeof(dng_map_table_t));
+  for(int i = 0; i < mt.table_size; i++)
+    pmt->table[i] = get_be_short(p);
+  return 0;
+}
+
+static int
+decode_map_polynomial(void **out, uint8_t **p, uint32_t len)
+{
+  dng_map_polynomial_t mp;
+  decode_dng_region(&mp.region, p);
+  mp.degree = get_be_long(p);
+  if(len != 36 + 8 * mp.degree)
+    return 1;
+  dng_map_polynomial_t *pmp =
+      calloc(1, sizeof(dng_map_polynomial_t) + mp.degree * sizeof(double));
+  *out = pmp;
+  memcpy(pmp, &mp, sizeof(dng_map_polynomial_t));
+  for(int i = 0; i < mp.degree; i++)
+    pmp->coefs[i] = get_be_double(p);
+  return 0;
+}
+
+static int
+decode_warp_rectilinear_2(void **out, uint8_t **p, uint32_t len)
+{
+  uint32_t count = get_be_long(p);
+  if(len != 24 + count * 76)
+    return 1;
+  dng_warp_rectilinear_2_t *wr =
+      calloc(1, sizeof(dng_warp_rectilinear_2_t) +
+                    count * sizeof(dng_warp_rectilinear_2_coef_t));
+  *out      = wr;
+  wr->count = count;
+  for(int i = 0; i < count; i++)
+  {
+    for(int j = 0; j < 15; j++)
+      wr->coefs[i].kr[j] = get_be_double(p);
+    for(int j = 0; j < 2; j++)
+      wr->coefs[i].kt[j] = get_be_double(p);
+    wr->coefs[i].min_valid_radius = get_be_double(p);
+    wr->coefs[i].max_valid_radius = get_be_double(p);
+  }
+  wr->center_x          = get_be_double(p);
+  wr->center_y          = get_be_double(p);
+  wr->reciprocal_radial = get_be_long(p);
+  return 0;
+}
+
+static int
+decode_opcode(dng_opcode_t *op, uint8_t **p)
+{
+  uint32_t op_id = get_be_long(p);
+  get_be_long(p);
+  uint32_t flags      = get_be_long(p);
+  uint32_t param_size = get_be_long(p);
+
+  op->id           = op_id;
+  op->optional     = (flags & 1) > 0;
+  op->preview_skip = (flags & 2) > 0;
+
+  switch(op_id)
+  {
+  case s_dngop_warp_rectilinear:
+    return decode_warp_rectilinear(&op->data, p, param_size);
+  case s_dngop_warp_fisheye:
+    return decode_warp_fisheye(&op->data, p, param_size);
+  case s_dngop_fix_vignette_radial:
+    return decode_fix_vignette_radial(&op->data, p, param_size);
+  case s_dngop_fix_bad_pixels_constant:
+    return decode_fix_bad_pixels_constant(&op->data, p, param_size);
+  case s_dngop_fix_bad_pixels_list:
+    return decode_fix_bad_pixels_list(&op->data, p, param_size);
+  case s_dngop_trim_bounds_t:
+    return decode_trim_bounds(&op->data, p, param_size);
+  case s_dngop_map_table_t:
+    return decode_map_table(&op->data, p, param_size);
+  case s_dngop_map_polynomial_t:
+    return decode_map_polynomial(&op->data, p, param_size);
+  case s_dngop_gain_map:
+    return decode_gain_map(&op->data, p, param_size);
+  case s_dngop_warp_rectilinear_2:
+    return decode_warp_rectilinear_2(&op->data, p, param_size);
+  default:
+    // Unknown or unsupported opcode; skip it.
+    *p += param_size;
+    return 0;
+  }
+}
+
+dng_opcode_list_t *
+dt_dng_opcode_list_decode(uint8_t *data, size_t len)
+{
+  uint8_t *p     = data;
+  uint32_t count = get_be_long(&p);
+
+  // Validate size of opcode list and of each opcode
+  for(int i = 0; i < count; i++)
+  {
+    p += 12;
+    uint32_t param_size = get_be_long(&p);
+    p += param_size;
+    if(p > &data[len])
+      return NULL;
+  }
+  if(p != &data[len])
+    return NULL;
+
+  dng_opcode_list_t *ops =
+      calloc(1, sizeof(dng_opcode_list_t) + count * sizeof(dng_opcode_t));
+
+  p = &data[4];
+  for(int i = 0; i < count; i++)
+  {
+    if(decode_opcode(&ops->ops[i], &p) != 0)
+    {
+      dt_dng_opcode_list_free(ops);
+      return NULL;
+    }
+  }
+
+  return ops;
+}
+
+void
+dt_dng_opcode_list_free(dng_opcode_list_t *ops)
+{
+  for(int i = 0; i < ops->count; i++)
+    free(ops->ops[i].data);
+  free(ops);
+}

--- a/src/pipe/dng_opcode.c
+++ b/src/pipe/dng_opcode.c
@@ -301,6 +301,8 @@ dt_dng_opcode_list_decode(uint8_t *data, size_t len)
 {
   uint8_t *p     = data;
   uint32_t count = get_be_long(&p);
+  if(count == 0)
+    return NULL;
 
   // Validate size of opcode list and of each opcode
   for(int i = 0; i < count; i++)
@@ -333,6 +335,8 @@ dt_dng_opcode_list_decode(uint8_t *data, size_t len)
 void
 dt_dng_opcode_list_free(dng_opcode_list_t *ops)
 {
+  if(ops == NULL)
+    return;
   for(int i = 0; i < ops->count; i++)
     free(ops->ops[i].data);
   free(ops);

--- a/src/pipe/dng_opcode.h
+++ b/src/pipe/dng_opcode.h
@@ -161,7 +161,3 @@ typedef struct
   dt_dng_warp_rectilinear_2_coef_t coefs[];
 }
 dt_dng_warp_rectilinear_2_t;
-
-dt_dng_opcode_list_t *dt_dng_opcode_list_decode(uint8_t *data, size_t len);
-
-void dt_dng_opcode_list_free(dt_dng_opcode_list_t *ops);

--- a/src/pipe/dng_opcode.h
+++ b/src/pipe/dng_opcode.h
@@ -16,23 +16,23 @@ typedef enum
   s_dngop_gain_map                = 9,
   s_dngop_warp_rectilinear_2      = 14
 }
-dng_opcode_id_t;
+dt_dng_opcode_id_t;
 
 typedef struct
 {
-  dng_opcode_id_t id;
+  dt_dng_opcode_id_t id;
   uint32_t        optional;
   uint32_t        preview_skip;
   void           *data;
 }
-dng_opcode_t;
+dt_dng_opcode_t;
 
 typedef struct
 {
   int          count;
-  dng_opcode_t ops[];
+  dt_dng_opcode_t ops[];
 }
-dng_opcode_list_t;
+dt_dng_opcode_list_t;
 
 typedef struct
 {
@@ -45,11 +45,11 @@ typedef struct
   uint32_t row_pitch;
   uint32_t col_pitch;
 }
-dng_region_t;
+dt_dng_region_t;
 
 typedef struct
 {
-  dng_region_t region;
+  dt_dng_region_t region;
   uint32_t     map_points_v;
   uint32_t     map_points_h;
   double       map_spacing_v;
@@ -59,38 +59,38 @@ typedef struct
   uint32_t     map_planes;
   float        map_gain[];
 }
-dng_gain_map_t;
+dt_dng_gain_map_t;
 
 typedef struct
 {
   double kr[4];
   double kt[2];
 }
-dng_warp_rectilinear_coef_t;
+dt_dng_warp_rectilinear_coef_t;
 
 typedef struct
 {
   uint32_t                    count;
   double                      center_x;
   double                      center_y;
-  dng_warp_rectilinear_coef_t coefs[];
+  dt_dng_warp_rectilinear_coef_t coefs[];
 }
-dng_warp_rectilinear_t;
+dt_dng_warp_rectilinear_t;
 
 typedef struct
 {
   double kr[4];
 }
-dng_warp_fisheye_coef_t;
+dt_dng_warp_fisheye_coef_t;
 
 typedef struct
 {
   uint32_t                count;
   double                  center_x;
   double                  center_y;
-  dng_warp_fisheye_coef_t coefs[];
+  dt_dng_warp_fisheye_coef_t coefs[];
 }
-dng_warp_fisheye_t;
+dt_dng_warp_fisheye_t;
 
 typedef struct
 {
@@ -98,14 +98,14 @@ typedef struct
   double center_x;
   double center_y;
 }
-dng_fix_vignette_radial_t;
+dt_dng_fix_vignette_radial_t;
 
 typedef struct
 {
   uint32_t constant;
   uint32_t bayer_phase;
 }
-dng_fix_bad_pixels_constant_t;
+dt_dng_fix_bad_pixels_constant_t;
 
 typedef struct
 {
@@ -116,7 +116,7 @@ typedef struct
   uint32_t *rects;
   uint32_t  _data[];
 }
-dng_fix_bad_pixels_list_t;
+dt_dng_fix_bad_pixels_list_t;
 
 typedef struct
 {
@@ -125,23 +125,23 @@ typedef struct
   uint32_t bottom;
   uint32_t right;
 }
-dng_trim_bounds_t;
+dt_dng_trim_bounds_t;
 
 typedef struct
 {
-  dng_region_t region;
+  dt_dng_region_t region;
   uint32_t     table_size;
   uint16_t     table[];
 }
-dng_map_table_t;
+dt_dng_map_table_t;
 
 typedef struct
 {
-  dng_region_t region;
+  dt_dng_region_t region;
   uint32_t     degree;
   double       coefs[];
 }
-dng_map_polynomial_t;
+dt_dng_map_polynomial_t;
 
 typedef struct
 {
@@ -150,7 +150,7 @@ typedef struct
   double min_valid_radius;
   double max_valid_radius;
 }
-dng_warp_rectilinear_2_coef_t;
+dt_dng_warp_rectilinear_2_coef_t;
 
 typedef struct
 {
@@ -158,10 +158,10 @@ typedef struct
   double                        center_x;
   double                        center_y;
   uint32_t                      reciprocal_radial;
-  dng_warp_rectilinear_2_coef_t coefs[];
+  dt_dng_warp_rectilinear_2_coef_t coefs[];
 }
-dng_warp_rectilinear_2_t;
+dt_dng_warp_rectilinear_2_t;
 
-dng_opcode_list_t *dt_dng_opcode_list_decode(uint8_t *data, size_t len);
+dt_dng_opcode_list_t *dt_dng_opcode_list_decode(uint8_t *data, size_t len);
 
-void dt_dng_opcode_list_free(dng_opcode_list_t *ops);
+void dt_dng_opcode_list_free(dt_dng_opcode_list_t *ops);

--- a/src/pipe/dng_opcode.h
+++ b/src/pipe/dng_opcode.h
@@ -1,0 +1,167 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum
+{
+  s_dngop_warp_rectilinear        = 1,
+  s_dngop_warp_fisheye            = 2,
+  s_dngop_fix_vignette_radial     = 3,
+  s_dngop_fix_bad_pixels_constant = 4,
+  s_dngop_fix_bad_pixels_list     = 5,
+  s_dngop_trim_bounds_t           = 6,
+  s_dngop_map_table_t             = 7,
+  s_dngop_map_polynomial_t        = 8,
+  s_dngop_gain_map                = 9,
+  s_dngop_warp_rectilinear_2      = 14
+}
+dng_opcode_id_t;
+
+typedef struct
+{
+  dng_opcode_id_t id;
+  uint32_t        optional;
+  uint32_t        preview_skip;
+  void           *data;
+}
+dng_opcode_t;
+
+typedef struct
+{
+  int          count;
+  dng_opcode_t ops[];
+}
+dng_opcode_list_t;
+
+typedef struct
+{
+  uint32_t top;
+  uint32_t left;
+  uint32_t bottom;
+  uint32_t right;
+  uint32_t plane;
+  uint32_t planes;
+  uint32_t row_pitch;
+  uint32_t col_pitch;
+}
+dng_region_t;
+
+typedef struct
+{
+  dng_region_t region;
+  uint32_t     map_points_v;
+  uint32_t     map_points_h;
+  double       map_spacing_v;
+  double       map_spacing_h;
+  double       map_origin_v;
+  double       map_origin_h;
+  uint32_t     map_planes;
+  float        map_gain[];
+}
+dng_gain_map_t;
+
+typedef struct
+{
+  double kr[4];
+  double kt[2];
+}
+dng_warp_rectilinear_coef_t;
+
+typedef struct
+{
+  uint32_t                    count;
+  double                      center_x;
+  double                      center_y;
+  dng_warp_rectilinear_coef_t coefs[];
+}
+dng_warp_rectilinear_t;
+
+typedef struct
+{
+  double kr[4];
+}
+dng_warp_fisheye_coef_t;
+
+typedef struct
+{
+  uint32_t                count;
+  double                  center_x;
+  double                  center_y;
+  dng_warp_fisheye_coef_t coefs[];
+}
+dng_warp_fisheye_t;
+
+typedef struct
+{
+  double k[5];
+  double center_x;
+  double center_y;
+}
+dng_fix_vignette_radial_t;
+
+typedef struct
+{
+  uint32_t constant;
+  uint32_t bayer_phase;
+}
+dng_fix_bad_pixels_constant_t;
+
+typedef struct
+{
+  uint32_t  bayer_phase;
+  uint32_t  bad_point_count;
+  uint32_t  bad_rect_count;
+  uint32_t *points;
+  uint32_t *rects;
+  uint32_t  _data[];
+}
+dng_fix_bad_pixels_list_t;
+
+typedef struct
+{
+  uint32_t top;
+  uint32_t left;
+  uint32_t bottom;
+  uint32_t right;
+}
+dng_trim_bounds_t;
+
+typedef struct
+{
+  dng_region_t region;
+  uint32_t     table_size;
+  uint16_t     table[];
+}
+dng_map_table_t;
+
+typedef struct
+{
+  dng_region_t region;
+  uint32_t     degree;
+  double       coefs[];
+}
+dng_map_polynomial_t;
+
+typedef struct
+{
+  double kr[15];
+  double kt[2];
+  double min_valid_radius;
+  double max_valid_radius;
+}
+dng_warp_rectilinear_2_coef_t;
+
+typedef struct
+{
+  uint32_t                      count;
+  double                        center_x;
+  double                        center_y;
+  uint32_t                      reciprocal_radial;
+  dng_warp_rectilinear_2_coef_t coefs[];
+}
+dng_warp_rectilinear_2_t;
+
+dng_opcode_list_t *dt_dng_opcode_list_decode(uint8_t *data, size_t len);
+
+void dt_dng_opcode_list_free(dng_opcode_list_t *ops);

--- a/src/pipe/flat.mk
+++ b/src/pipe/flat.mk
@@ -1,7 +1,6 @@
 PIPE_O=\
 pipe/alloc.o\
 pipe/connector.o\
-pipe/dng_opcode.o\
 pipe/global.o\
 pipe/graph.o\
 pipe/graph-io.o\

--- a/src/pipe/flat.mk
+++ b/src/pipe/flat.mk
@@ -1,6 +1,7 @@
 PIPE_O=\
 pipe/alloc.o\
 pipe/connector.o\
+pipe/dng_opcode.o\
 pipe/global.o\
 pipe/graph.o\
 pipe/graph-io.o\

--- a/src/pipe/module.h
+++ b/src/pipe/module.h
@@ -17,6 +17,7 @@
 #include "global.h"
 #include "connector.h"
 #include "metadata.h"
+#include "dng_opcode.h"
 
 // bare essential meta data that travels
 // with a (raw) input buffer along the graph.
@@ -52,6 +53,8 @@ typedef struct dt_image_params_t
   float noise_a;              // raw noise estimate, gaussian part
   float noise_b;              // raw noise estimate, poissonian part
   dt_token_t input_name;      // remember the name, "main" has special rights
+
+  dng_opcode_list_t *dng_opcode_lists[3];
 
   // optional extra data to travel along with the image until the output:
   dt_image_metadata_t *meta;  // owned by the i-* module that sets it

--- a/src/pipe/module.h
+++ b/src/pipe/module.h
@@ -54,7 +54,7 @@ typedef struct dt_image_params_t
   float noise_b;              // raw noise estimate, poissonian part
   dt_token_t input_name;      // remember the name, "main" has special rights
 
-  dng_opcode_list_t *dng_opcode_lists[3];
+  dt_dng_opcode_list_t *dng_opcode_lists[3];
 
   // optional extra data to travel along with the image until the output:
   dt_image_metadata_t *meta;  // owned by the i-* module that sets it

--- a/src/pipe/modules/dngop2/connectors
+++ b/src/pipe/modules/dngop2/connectors
@@ -1,0 +1,2 @@
+input:read:rggb:*
+output:write:rggb:*

--- a/src/pipe/modules/dngop2/gainmap.comp
+++ b/src/pipe/modules/dngop2/gainmap.comp
@@ -5,6 +5,14 @@
 
 layout(local_size_x = DT_LOCAL_SIZE_X, local_size_y = DT_LOCAL_SIZE_Y, local_size_z = 1) in;
 
+layout(push_constant, std140) uniform push_t
+{
+  ivec2 corner_lt;
+  ivec2 corner_rb;
+  vec2 map_origin;
+  vec2 map_scale;
+} push;
+
 layout( // input f16 buffer rgb
     set = 1, binding = 0
 ) uniform sampler2D img_in;
@@ -14,14 +22,26 @@ layout( // output f16 buffer rgb
 ) uniform writeonly image2D img_out;
 
 layout( // GainMap data
-  set = 1, binding = 2
+    set = 1, binding = 2
 ) uniform sampler2D gainmap_in;
 
 void
 main()
 {
   ivec2 ipos = ivec2(gl_GlobalInvocationID);
-  if(any(greaterThanEqual(ipos, imageSize(img_out)))) return;
-  vec3 rgb = texelFetch(img_in, ipos, 0).rgb;
-  imageStore(img_out, ipos, vec4(rgb, 1.0));
+  // only apply operation within specified bounds
+  if(any(lessThan(ipos, push.corner_lt))) return;
+  if(any(greaterThanEqual(ipos, push.corner_rb))) return;
+
+  // pixel location as a fraction of the entire image
+  vec2 pos = (0.5 + ipos) / imageSize(img_out);
+  // pixel location relative to the GainMap which might not cover the entire image
+  // points outside the map use the nearest value at the edge of the map
+  pos = clamp((pos * push.map_scale) - push.map_origin, 0., 1.);
+  // get the gains for all channels at this point
+  vec4 gains = texture(gainmap_in, pos);
+  // select and apply the appropriate gain for this Bayer filter
+  float gain = gains[(ipos.x & 1) + (ipos.y & 1) * 2];
+  float v = texelFetch(img_in, ipos, 0).r;
+  imageStore(img_out, ipos, vec4(v * gain, 0., 0., 0.));
 }

--- a/src/pipe/modules/dngop2/gainmap.comp
+++ b/src/pipe/modules/dngop2/gainmap.comp
@@ -1,0 +1,27 @@
+#version 460
+#extension GL_GOOGLE_include_directive    : enable
+
+#include "shared.glsl"
+
+layout(local_size_x = DT_LOCAL_SIZE_X, local_size_y = DT_LOCAL_SIZE_Y, local_size_z = 1) in;
+
+layout( // input f16 buffer rgb
+    set = 1, binding = 0
+) uniform sampler2D img_in;
+
+layout( // output f16 buffer rgb
+    set = 1, binding = 1
+) uniform writeonly image2D img_out;
+
+layout( // GainMap data
+  set = 1, binding = 2
+) uniform sampler2D gainmap_in;
+
+void
+main()
+{
+  ivec2 ipos = ivec2(gl_GlobalInvocationID);
+  if(any(greaterThanEqual(ipos, imageSize(img_out)))) return;
+  vec3 rgb = texelFetch(img_in, ipos, 0).rgb;
+  imageStore(img_out, ipos, vec4(rgb, 1.0));
+}

--- a/src/pipe/modules/dngop2/main.c
+++ b/src/pipe/modules/dngop2/main.c
@@ -1,0 +1,177 @@
+#include "modules/api.h"
+
+// Set of four GainMaps to be applied to a Bayer mosaic image.
+// There is one for each of the four filters of a Bayer block:
+// 0: upper left 1: upper right 2: lower left 3: lower right
+// All four have the exact same shape and are to be applied to the exact same
+// region of the image.
+typedef struct gain_maps_bayer_t
+{
+  dt_dng_gain_map_t *gm[4];
+}
+gain_maps_bayer_t;
+
+typedef struct dngop2_data_t
+{
+  gain_maps_bayer_t gain_maps_bayer;
+}
+dngop2_data_t;
+
+static int
+get_gain_maps_bayer(dt_dng_opcode_list_t *op_list, int index, gain_maps_bayer_t *gmb)
+{
+  // We are looking for four consecutive GainMaps in the opcode list starting at
+  // index which are to be applied to a Bayer mosaic image.
+  if(op_list->count - index < 4)
+    return 0;
+  dt_dng_opcode_t *ops = op_list->ops;
+  for(int i=0;i<4;i++)
+    if(ops[i].id != s_dngop_gain_map)
+      return 0;
+  // We have four GainMaps - is there one for each Bayer filter?
+  for(int i=0;i<4;i++)
+    gmb->gm[i] = NULL;
+  for(int i=0;i<4;i++)
+  {
+    dt_dng_gain_map_t *gm = (dt_dng_gain_map_t *)ops[i].data;
+    // Check that this is for a Bayer filter
+    if(!(gm->region.plane == 0 && gm->region.planes == 1 && gm->map_planes == 1 &&
+         gm->region.row_pitch == 2 && gm->region.col_pitch == 2))
+      return 0;
+    // Check that this is not a 1x1 no-op
+    if(gm->map_points_h < 2 && gm->map_points_v < 2)
+      return 0;
+    int filter = ((gm->region.top & 1) << 1) + (gm->region.left & 1);
+    gmb->gm[filter] = gm;
+  }
+  // Check that we found all four GainMaps
+  for(int i=0;i<4;i++)
+    if(gmb->gm[i] == NULL)
+      return 0;
+  // Check that all four GainMaps have the exact same shape
+  for(int i=1;i<4;i++)
+  {
+    if (gmb->gm[0]->map_points_h != gmb->gm[i]->map_points_h ||
+        gmb->gm[0]->map_points_v != gmb->gm[i]->map_points_v ||
+        gmb->gm[0]->map_spacing_h != gmb->gm[i]->map_spacing_h ||
+        gmb->gm[0]->map_spacing_v != gmb->gm[i]->map_spacing_v ||
+        gmb->gm[0]->map_origin_h != gmb->gm[i]->map_origin_h ||
+        gmb->gm[0]->map_origin_v != gmb->gm[i]->map_origin_v)
+      return 0;
+  }
+
+  return 1;
+}
+
+static void
+get_gain_maps_bayer_data(gain_maps_bayer_t *gmb, float *data)
+{
+  const int wd = gmb->gm[0]->map_points_h;
+  const int ht = gmb->gm[0]->map_points_v;
+  for(int i=0;i<ht;i++)
+    for(int j=0;j<wd;j++)
+      for(int c=0;c<4;c++)
+        data[(i*wd+j)*4+c] = gmb->gm[c]->map_gain[(i*wd+j)];
+}
+
+int
+init(dt_module_t *mod)
+{
+  dngop2_data_t *d = calloc(sizeof(*d), 1);
+  mod->data = d;
+  return 0;
+}
+
+void
+cleanup(dt_module_t *mod)
+{
+  dngop2_data_t *d = mod->data;
+  free(d);
+  mod->data = 0;
+}
+
+int
+read_source(
+    dt_module_t             *mod,
+    void                    *mapped,
+    dt_read_source_params_t *p)
+{
+  dngop2_data_t *d = mod->data;
+  if(p->node->name == dt_token("gmdata"))
+    get_gain_maps_bayer_data(&d->gain_maps_bayer, (float *)mapped);
+  return 0;
+}
+
+static void
+create_nodes_op_list(
+    dt_graph_t  *graph,
+    dt_module_t *module,
+    dt_dng_opcode_list_t *op_list)
+{
+  dngop2_data_t *d = module->data;
+
+  // id of the preceding opcode node's connector. -1 indicates this is the first
+  // opcode and should be connected to the module input.
+  int prev_nid = -1;
+  int prev_nc;
+
+  int has_gain_map = 0;
+  for(int iop=0;iop<op_list->count;iop++)
+  {
+    gain_maps_bayer_t gain_maps_bayer;
+    if(get_gain_maps_bayer(op_list, iop, &gain_maps_bayer))
+    {
+      if(has_gain_map)
+        continue; // Only apply one set even if there are more in the file
+
+      const int wd = gain_maps_bayer.gm[0]->map_points_h;
+      const int ht = gain_maps_bayer.gm[0]->map_points_v;
+      dt_roi_t gmdata_roi = (dt_roi_t){ .wd = wd, .ht = ht };
+      const int id_gmdata = dt_node_add(graph, module, "dngop2", "source",
+        wd, ht, 1,
+        0, 0, 1,
+        "source", "source", "rgba", "f32", &gmdata_roi);
+
+      const int id_gainmap = dt_node_add(graph, module, "dngop2", "gainmap",
+        module->connector[0].roi.wd, module->connector[0].roi.ht, 1,
+        0, 0, 3,
+        "input",  "read",  "rgba", "f16", &module->connector[0].roi,
+        "output", "write", "rgba", "f16", &module->connector[0].roi,
+        "gmdata", "read",  "rgba", "f32", &gmdata_roi);
+
+      CONN(dt_node_connect(graph, id_gmdata, 0, id_gainmap, 2));
+
+      memcpy(&d->gain_maps_bayer, &gain_maps_bayer, sizeof(gain_maps_bayer));
+      has_gain_map = 1;
+      iop += 3; // Skip over all four of the GainMap opcodes
+
+      if(prev_nid == -1)
+        dt_connector_copy(graph, module, 0, id_gainmap, 0);
+      else
+        CONN(dt_node_connect(graph, prev_nid, prev_nc, id_gainmap, 0));
+      prev_nid = id_gainmap;
+      prev_nc = 1;
+    }
+  }
+
+  if(prev_nid == -1)
+    dt_connector_bypass(graph, module, 0, 1);
+  else {
+    dt_connector_copy(graph, module, 1, prev_nid, prev_nc);
+  }
+}
+
+void
+create_nodes(
+    dt_graph_t  *graph,
+    dt_module_t *module)
+{
+  if(module->img_param.dng_opcode_lists[1] == NULL)
+  {
+    dt_connector_bypass(graph, module, 0, 1);
+  }
+  else
+  {
+    create_nodes_op_list(graph, module, module->img_param.dng_opcode_lists[1]);
+  }
+}

--- a/src/pipe/modules/dngop2/readme.md
+++ b/src/pipe/modules/dngop2/readme.md
@@ -1,0 +1,1 @@
+# dngop2: DNG OpcodeList2 processing

--- a/src/pipe/modules/i-raw/dng_opcode_decode.c
+++ b/src/pipe/modules/i-raw/dng_opcode_decode.c
@@ -70,7 +70,7 @@ decode_warp_rectilinear(void **out, uint8_t **p, uint32_t len)
   if(len != 20 + count * 48)
     return 1;
   dt_dng_warp_rectilinear_t *wr =
-      calloc(1, sizeof(dt_dng_warp_rectilinear_t) +
+      (dt_dng_warp_rectilinear_t *)calloc(1, sizeof(dt_dng_warp_rectilinear_t) +
                     count * sizeof(dt_dng_warp_rectilinear_coef_t));
   *out      = wr;
   wr->count = count;
@@ -92,7 +92,7 @@ decode_warp_fisheye(void **out, uint8_t **p, uint32_t len)
   uint32_t count = get_be_long(p);
   if(len != 20 + count * 32)
     return 1;
-  dt_dng_warp_fisheye_t *wr = calloc(
+  dt_dng_warp_fisheye_t *wr = (dt_dng_warp_fisheye_t *)calloc(
       1, sizeof(dt_dng_warp_fisheye_t) + count * sizeof(dt_dng_warp_fisheye_coef_t));
   *out      = wr;
   wr->count = count;
@@ -123,7 +123,7 @@ decode_gain_map(void **out, uint8_t **p, uint32_t len)
   if(len != 76 + count * sizeof(float))
     return 1;
   dt_dng_gain_map_t *pgm =
-      calloc(1, sizeof(dt_dng_gain_map_t) + count * sizeof(float));
+      (dt_dng_gain_map_t *)calloc(1, sizeof(dt_dng_gain_map_t) + count * sizeof(float));
   memcpy(pgm, &gm, sizeof(dt_dng_gain_map_t));
   *out = pgm;
   for(int i = 0; i < count; i++)
@@ -137,7 +137,8 @@ decode_fix_vignette_radial(void **out, uint8_t **p, uint32_t len)
 {
   if(len != 56)
     return 1;
-  dt_dng_fix_vignette_radial_t *fvr = calloc(1, sizeof(dt_dng_fix_vignette_radial_t));
+  dt_dng_fix_vignette_radial_t *fvr = (dt_dng_fix_vignette_radial_t *)calloc(
+      1, sizeof(dt_dng_fix_vignette_radial_t));
   *out                           = fvr;
   for(int j = 0; j < 5; j++)
     fvr->k[j] = get_be_double(p);
@@ -152,7 +153,7 @@ decode_fix_bad_pixels_constant(void **out, uint8_t **p, uint32_t len)
   if(len != 8)
     return 1;
   dt_dng_fix_bad_pixels_constant_t *fbpc =
-      calloc(1, sizeof(dt_dng_fix_bad_pixels_constant_t));
+      (dt_dng_fix_bad_pixels_constant_t *)calloc(1, sizeof(dt_dng_fix_bad_pixels_constant_t));
   *out              = fbpc;
   fbpc->constant    = get_be_long(p);
   fbpc->bayer_phase = get_be_long(p);
@@ -167,7 +168,7 @@ decode_fix_bad_pixels_list(void **out, uint8_t **p, uint32_t len)
   uint32_t bad_rect_count  = get_be_long(p);
   if(len != 12 + bad_point_count * 8 + bad_rect_count * 16)
     return 1;
-  dt_dng_fix_bad_pixels_list_t *fbpl = calloc(
+  dt_dng_fix_bad_pixels_list_t *fbpl = (dt_dng_fix_bad_pixels_list_t *)calloc(
       1, sizeof(dt_dng_fix_bad_pixels_list_t) +
              (bad_point_count * 2 + bad_rect_count * 4) * sizeof(uint32_t));
   *out                  = fbpl;
@@ -186,7 +187,8 @@ decode_trim_bounds(void **out, uint8_t **p, uint32_t len)
 {
   if(len != 16)
     return 1;
-  dt_dng_trim_bounds_t *tb = calloc(1, sizeof(dt_dng_trim_bounds_t));
+  dt_dng_trim_bounds_t *tb = (dt_dng_trim_bounds_t *)calloc(
+      1, sizeof(dt_dng_trim_bounds_t));
   *out                  = tb;
   tb->top               = get_be_long(p);
   tb->left              = get_be_long(p);
@@ -203,8 +205,8 @@ decode_map_table(void **out, uint8_t **p, uint32_t len)
   mt.table_size = get_be_long(p);
   if(len != 36 + 2 * mt.table_size)
     return 1;
-  dt_dng_map_table_t *pmt =
-      calloc(1, sizeof(dt_dng_map_table_t) + mt.table_size * sizeof(uint16_t));
+  dt_dng_map_table_t *pmt = (dt_dng_map_table_t *)calloc(
+      1, sizeof(dt_dng_map_table_t) + mt.table_size * sizeof(uint16_t));
   *out = pmt;
   memcpy(pmt, &mt, sizeof(dt_dng_map_table_t));
   for(int i = 0; i < mt.table_size; i++)
@@ -220,8 +222,8 @@ decode_map_polynomial(void **out, uint8_t **p, uint32_t len)
   mp.degree = get_be_long(p);
   if(len != 36 + 8 * mp.degree)
     return 1;
-  dt_dng_map_polynomial_t *pmp =
-      calloc(1, sizeof(dt_dng_map_polynomial_t) + mp.degree * sizeof(double));
+  dt_dng_map_polynomial_t *pmp = (dt_dng_map_polynomial_t *)calloc(
+      1, sizeof(dt_dng_map_polynomial_t) + mp.degree * sizeof(double));
   *out = pmp;
   memcpy(pmp, &mp, sizeof(dt_dng_map_polynomial_t));
   for(int i = 0; i < mp.degree; i++)
@@ -235,8 +237,8 @@ decode_warp_rectilinear_2(void **out, uint8_t **p, uint32_t len)
   uint32_t count = get_be_long(p);
   if(len != 24 + count * 76)
     return 1;
-  dt_dng_warp_rectilinear_2_t *wr =
-      calloc(1, sizeof(dt_dng_warp_rectilinear_2_t) +
+  dt_dng_warp_rectilinear_2_t *wr = (dt_dng_warp_rectilinear_2_t *)calloc( 
+      1, sizeof(dt_dng_warp_rectilinear_2_t) +
                     count * sizeof(dt_dng_warp_rectilinear_2_coef_t));
   *out      = wr;
   wr->count = count;
@@ -263,7 +265,7 @@ decode_opcode(dt_dng_opcode_t *op, uint8_t **p)
   uint32_t flags      = get_be_long(p);
   uint32_t param_size = get_be_long(p);
 
-  op->id           = op_id;
+  op->id           = (dt_dng_opcode_id_t)op_id;
   op->optional     = (flags & 1) > 0;
   op->preview_skip = (flags & 2) > 0;
 
@@ -296,8 +298,18 @@ decode_opcode(dt_dng_opcode_t *op, uint8_t **p)
   }
 }
 
-dt_dng_opcode_list_t *
-dt_dng_opcode_list_decode(uint8_t *data, size_t len)
+static void
+dng_opcode_list_free(dt_dng_opcode_list_t *ops)
+{
+  if(ops == NULL)
+    return;
+  for(int i = 0; i < ops->count; i++)
+    free(ops->ops[i].data);
+  free(ops);
+}
+
+static dt_dng_opcode_list_t *
+dng_opcode_list_decode(uint8_t *data, size_t len)
 {
   uint8_t *p     = data;
   uint32_t count = get_be_long(&p);
@@ -316,8 +328,8 @@ dt_dng_opcode_list_decode(uint8_t *data, size_t len)
   if(p != &data[len])
     return NULL;
 
-  dt_dng_opcode_list_t *ops =
-      calloc(1, sizeof(dt_dng_opcode_list_t) + count * sizeof(dt_dng_opcode_t));
+  dt_dng_opcode_list_t *ops = (dt_dng_opcode_list_t *)calloc(
+      1, sizeof(dt_dng_opcode_list_t) + count * sizeof(dt_dng_opcode_t));
   ops->count = count;
 
   p = &data[4];
@@ -325,20 +337,10 @@ dt_dng_opcode_list_decode(uint8_t *data, size_t len)
   {
     if(decode_opcode(&ops->ops[i], &p) != 0)
     {
-      dt_dng_opcode_list_free(ops);
+      dng_opcode_list_free(ops);
       return NULL;
     }
   }
 
   return ops;
-}
-
-void
-dt_dng_opcode_list_free(dt_dng_opcode_list_t *ops)
-{
-  if(ops == NULL)
-    return;
-  for(int i = 0; i < ops->count; i++)
-    free(ops->ops[i].data);
-  free(ops);
 }

--- a/src/pipe/modules/i-raw/exif.h
+++ b/src/pipe/modules/i-raw/exif.h
@@ -256,7 +256,7 @@ int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData, dt_
         // this is a DNG file - locate the primary raw image
         std::string primary_group;
         for(pos = exifData.begin(); pos != exifData.end(); ++pos)
-          if(strcmp(pos->tagName().c_str(), "NewSubfileType") == 0 && pos->toUint32() == 0)
+          if(strcmp(pos->tagName().c_str(), "NewSubfileType") == 0 && pos->toLong() == 0)
           {
             primary_group = pos->groupName();
             break;

--- a/src/pipe/modules/i-raw/exif.h
+++ b/src/pipe/modules/i-raw/exif.h
@@ -19,6 +19,7 @@
 extern "C" {
 #include "module.h"
 #include "core/fs.h"
+#include "dng_opcode.h"
 }
 
 #include <cassert>
@@ -54,7 +55,7 @@ typedef enum dt_exif_image_orientation_t
 }
 dt_exif_image_orientation_t;
 
-int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData)
+int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData, dng_opcode_list_t **dng_opcode_lists)
 {
   try
   {
@@ -248,6 +249,44 @@ int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData)
         for(int k=0;k<9;k++)
           ip->cam_to_rec2020[k] = cam_to_rec2020[k];
       }
+
+      // get and decode DNG opcode lists  
+      if(dng_opcode_lists != nullptr && FIND_EXIF_TAG("Exif.Image.DNGVersion"))
+      {
+        // this is a DNG file - locate the primary raw image
+        std::string primary_group;
+        for(pos = exifData.begin(); pos != exifData.end(); ++pos)
+          if(strcmp(pos->tagName().c_str(), "NewSubfileType") == 0 && pos->toUint32() == 0)
+          {
+            primary_group = pos->groupName();
+            break;
+          }
+        if(!primary_group.empty())
+        {
+          if(FIND_EXIF_TAG("Exif." + primary_group + ".OpcodeList1"))
+          {
+            uint8_t *data = (uint8_t *)malloc(pos->size());
+            pos->copy(data, Exiv2::invalidByteOrder);
+            dng_opcode_lists[0] = dt_dng_opcode_list_decode(data, pos->size());
+            free(data);
+          }
+          if(FIND_EXIF_TAG("Exif." + primary_group + ".OpcodeList2"))
+          {
+            uint8_t *data = (uint8_t *)malloc(pos->size());
+            std::cout << "op2 size " << pos->size() << std::endl;
+            pos->copy(data, Exiv2::invalidByteOrder);
+            dng_opcode_lists[1] = dt_dng_opcode_list_decode(data, pos->size());
+            free(data);
+          }
+          if(FIND_EXIF_TAG("Exif." + primary_group + ".OpcodeList3"))
+          {
+            uint8_t *data = (uint8_t *)malloc(pos->size());
+            pos->copy(data, Exiv2::invalidByteOrder);
+            dng_opcode_lists[2] = dt_dng_opcode_list_decode(data, pos->size());
+            free(data);
+          }
+        }
+      }
     }
     return 0;
   }
@@ -264,7 +303,7 @@ int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData)
 /** read the metadata of an image.
  * XMP data trumps IPTC data trumps EXIF data
  */
-int dt_exif_read(dt_image_params_t *ip, const char *path)
+int dt_exif_read(dt_image_params_t *ip, const char *path, dng_opcode_list_t **dng_opcode_lists)
 {
   // at least set datetime taken to something useful in case there is no exif
   // data in this file (pfm, png, ...)
@@ -279,7 +318,7 @@ int dt_exif_read(dt_image_params_t *ip, const char *path)
     // EXIF metadata
     Exiv2::ExifData &exifData = image->exifData();
     if(!exifData.empty())
-      return dt_exif_read_exif_data(ip, exifData);
+      return dt_exif_read_exif_data(ip, exifData, dng_opcode_lists);
     return 1;
   }
   catch(Exiv2::AnyError &e)

--- a/src/pipe/modules/i-raw/exif.h
+++ b/src/pipe/modules/i-raw/exif.h
@@ -19,7 +19,7 @@
 extern "C" {
 #include "module.h"
 #include "core/fs.h"
-#include "dng_opcode_decode.h"
+#include "dng_opcode.h"
 }
 
 #include <cassert>

--- a/src/pipe/modules/i-raw/exif.h
+++ b/src/pipe/modules/i-raw/exif.h
@@ -55,7 +55,7 @@ typedef enum dt_exif_image_orientation_t
 }
 dt_exif_image_orientation_t;
 
-int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData, dng_opcode_list_t **dng_opcode_lists)
+int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData, dt_dng_opcode_list_t **dng_opcode_lists)
 {
   try
   {
@@ -303,7 +303,7 @@ int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData, dng
 /** read the metadata of an image.
  * XMP data trumps IPTC data trumps EXIF data
  */
-int dt_exif_read(dt_image_params_t *ip, const char *path, dng_opcode_list_t **dng_opcode_lists)
+int dt_exif_read(dt_image_params_t *ip, const char *path, dt_dng_opcode_list_t **dng_opcode_lists)
 {
   // at least set datetime taken to something useful in case there is no exif
   // data in this file (pfm, png, ...)

--- a/src/pipe/modules/i-raw/exif.h
+++ b/src/pipe/modules/i-raw/exif.h
@@ -273,7 +273,6 @@ int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData, dt_
           if(FIND_EXIF_TAG("Exif." + primary_group + ".OpcodeList2"))
           {
             uint8_t *data = (uint8_t *)malloc(pos->size());
-            std::cout << "op2 size " << pos->size() << std::endl;
             pos->copy(data, Exiv2::invalidByteOrder);
             dng_opcode_lists[1] = dt_dng_opcode_list_decode(data, pos->size());
             free(data);

--- a/src/pipe/modules/i-raw/exif.h
+++ b/src/pipe/modules/i-raw/exif.h
@@ -19,7 +19,7 @@
 extern "C" {
 #include "module.h"
 #include "core/fs.h"
-#include "dng_opcode.h"
+#include "dng_opcode_decode.h"
 }
 
 #include <cassert>
@@ -267,21 +267,21 @@ int dt_exif_read_exif_data(dt_image_params_t *ip, Exiv2::ExifData &exifData, dt_
           {
             uint8_t *data = (uint8_t *)malloc(pos->size());
             pos->copy(data, Exiv2::invalidByteOrder);
-            dng_opcode_lists[0] = dt_dng_opcode_list_decode(data, pos->size());
+            dng_opcode_lists[0] = dng_opcode_list_decode(data, pos->size());
             free(data);
           }
           if(FIND_EXIF_TAG("Exif." + primary_group + ".OpcodeList2"))
           {
             uint8_t *data = (uint8_t *)malloc(pos->size());
             pos->copy(data, Exiv2::invalidByteOrder);
-            dng_opcode_lists[1] = dt_dng_opcode_list_decode(data, pos->size());
+            dng_opcode_lists[1] = dng_opcode_list_decode(data, pos->size());
             free(data);
           }
           if(FIND_EXIF_TAG("Exif." + primary_group + ".OpcodeList3"))
           {
             uint8_t *data = (uint8_t *)malloc(pos->size());
             pos->copy(data, Exiv2::invalidByteOrder);
-            dng_opcode_lists[2] = dt_dng_opcode_list_decode(data, pos->size());
+            dng_opcode_lists[2] = dng_opcode_list_decode(data, pos->size());
             free(data);
           }
         }

--- a/src/pipe/modules/i-raw/flat.mk
+++ b/src/pipe/modules/i-raw/flat.mk
@@ -45,7 +45,9 @@ MOD_LDFLAGS=pipe/modules/i-raw/rawloader-c/target/release/librawloader.a
 MOD_CFLAGS=-Ipipe/modules/i-raw/rawloader-c
 pipe/modules/i-raw/libi-raw.so: pipe/modules/i-raw/rawloader-c/target/release/librawloader.a
 
-pipe/modules/i-raw/rawloader-c/target/release/librawloader.a: pipe/modules/i-raw/rawloader-c/lib.rs pipe/modules/i-raw/rawloader-c/Cargo.toml
+pipe/modules/i-raw/rawloader-c/target/release/librawloader.a: pipe/modules/i-raw/rawloader-c/lib.rs pipe/modules/i-raw/rawloader-c/Cargo.toml 
 	cd pipe/modules/i-raw/rawloader-c; cargo update; cargo build --release
 	touch pipe/modules/i-raw/rawloader-c/target/release/librawloader.a
 endif
+
+pipe/modules/i-raw/libi-raw.so:pipe/modules/i-raw/dng_opcode_decode.c

--- a/src/pipe/modules/i-raw/main.c
+++ b/src/pipe/modules/i-raw/main.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <time.h>
 
+#include "dng_opcode_decode.c"
+
 typedef struct rawinput_buf_t
 {
   rawimage_t img;
@@ -14,7 +16,7 @@ typedef struct rawinput_buf_t
   char filename[PATH_MAX];
   int frame;
   int ox, oy;
-  dng_opcode_list_t *dng_opcode_lists[3];
+  dt_dng_opcode_list_t *dng_opcode_lists[3];
 }
 rawinput_buf_t;
   
@@ -25,7 +27,7 @@ free_raw(dt_module_t *mod)
   rl_deallocate(mod_data->img.data, mod_data->len);
   for(int i=0;i<3;i++)
   {
-    dt_dng_opcode_list_free(mod_data->dng_opcode_lists[i]);
+    dng_opcode_list_free(mod_data->dng_opcode_lists[i]);
     mod_data->dng_opcode_lists[i] = NULL;
   }
   mod_data->filename[0] = 0;
@@ -57,7 +59,7 @@ load_raw(
     if(mod_data->img.dng_opcode_lists_len[i] > 0)
     {
       // decode the raw opcode list into C structures we can access directly
-      mod_data->dng_opcode_lists[i] = dt_dng_opcode_list_decode(
+      mod_data->dng_opcode_lists[i] = dng_opcode_list_decode(
         mod_data->img.dng_opcode_lists[i], mod_data->img.dng_opcode_lists_len[i]);
       // free the raw opcode list now that we have decoded it
       rl_deallocate(mod_data->img.dng_opcode_lists[i], mod_data->img.dng_opcode_lists_len[i]);

--- a/src/pipe/modules/i-raw/main.c
+++ b/src/pipe/modules/i-raw/main.c
@@ -21,6 +21,12 @@ free_raw(dt_module_t *mod)
 {
   rawinput_buf_t *mod_data = (rawinput_buf_t *)mod->data;
   rl_deallocate(mod_data->img.data, mod_data->len);
+  if(mod_data->img.dng_opcode_list_1_len > 0)
+    rl_deallocate(mod_data->img.dng_opcode_list_1, mod_data->img.dng_opcode_list_1_len);
+  if(mod_data->img.dng_opcode_list_2_len > 0)
+    rl_deallocate(mod_data->img.dng_opcode_list_2, mod_data->img.dng_opcode_list_2_len);
+  if(mod_data->img.dng_opcode_list_3_len > 0)
+    rl_deallocate(mod_data->img.dng_opcode_list_3, mod_data->img.dng_opcode_list_3_len);
   mod_data->filename[0] = 0;
 }
 

--- a/src/pipe/modules/i-raw/main.cc
+++ b/src/pipe/modules/i-raw/main.cc
@@ -38,7 +38,7 @@ typedef struct rawinput_buf_t
   std::unique_ptr<rawspeed::RawDecoder> d;
   char filename[PATH_MAX] = {0};
   int ox, oy;
-  dng_opcode_list_t *dng_opcode_lists[3];
+  dt_dng_opcode_list_t *dng_opcode_lists[3];
 }
 rawinput_buf_t;
 

--- a/src/pipe/modules/i-raw/main.cc
+++ b/src/pipe/modules/i-raw/main.cc
@@ -1,6 +1,8 @@
 // unfortunately, since we'll link to rawspeed, we need c++ here.
 extern "C" {
 #include "modules/api.h"
+#include "dng_opcode.h"
+#include "dng_opcode_decode.c"
 }
 #include "RawSpeed-API.h"
 #include "mat3.h"
@@ -89,7 +91,7 @@ free_raw(dt_module_t *mod)
   rawinput_buf_t *mod_data = (rawinput_buf_t *)mod->data;
   for(int i=0;i<3;i++)
   {
-    dt_dng_opcode_list_free(mod_data->dng_opcode_lists[i]);
+    dng_opcode_list_free(mod_data->dng_opcode_lists[i]);
     mod_data->dng_opcode_lists[i] = NULL;
   }
   if(mod_data->d.get()) mod_data->d.reset();

--- a/src/pipe/modules/i-raw/rawloader-c/Cargo.toml
+++ b/src/pipe/modules/i-raw/rawloader-c/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib"]
 [dependencies]
 # rawler = {path = "../dnglab/rawler", version = "0.5.1"}
 # rawler = { git = "https://github.com/dnglab/dnglab", rev = "af71c11f" }
-rawler = { git = "https://github.com/paolodepetrillo/dnglab", branch = "exif-dng-opcodes" }
+rawler = { git = "https://github.com/paolodepetrillo/dnglab", branch = "exif-dng-opcodes-2" }
 libc = "0.2.148"
 
 [profile.release]

--- a/src/pipe/modules/i-raw/rawloader-c/Cargo.toml
+++ b/src/pipe/modules/i-raw/rawloader-c/Cargo.toml
@@ -13,7 +13,8 @@ crate-type = ["staticlib"]
 
 [dependencies]
 # rawler = {path = "../dnglab/rawler", version = "0.5.1"}
-rawler = { git = "https://github.com/dnglab/dnglab", rev = "af71c11f" }
+# rawler = { git = "https://github.com/dnglab/dnglab", rev = "af71c11f" }
+rawler = { git = "https://github.com/paolodepetrillo/dnglab", branch = "exif-dng-opcodes" }
 libc = "0.2.148"
 
 [profile.release]

--- a/src/pipe/modules/i-raw/rawloader-c/lib.rs
+++ b/src/pipe/modules/i-raw/rawloader-c/lib.rs
@@ -76,9 +76,14 @@ unsafe fn copy_metadata(path : &str, rawimg : *mut c_rawimage) -> Result<()>
   match md.exif.focal_length      { Some(v) => { (*rawimg).focal_length = v.try_into().ok().unwrap(); } None => {}}
   match md.exif.orientation       { Some(v) => { (*rawimg).orientation  = v as u32; } None => {}}
   match md.exif.create_date       { Some(d) => { copy_string(&d, &mut (*rawimg).datetime) } None => {}}
-  match md.exif.dng_opcode_list_1 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_lists[0], &mut (*rawimg).dng_opcode_lists_len[0]) } None => {}}
-  match md.exif.dng_opcode_list_2 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_lists[1], &mut (*rawimg).dng_opcode_lists_len[1]) } None => {}}
-  match md.exif.dng_opcode_list_3 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_lists[2], &mut (*rawimg).dng_opcode_lists_len[2]) } None => {}}
+  match md.dng_opcode_lists {
+    Some(lists) => {
+      match lists.list_1 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_lists[0], &mut (*rawimg).dng_opcode_lists_len[0]) } None => {}}
+      match lists.list_2 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_lists[1], &mut (*rawimg).dng_opcode_lists_len[1]) } None => {}}
+      match lists.list_3 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_lists[2], &mut (*rawimg).dng_opcode_lists_len[2]) } None => {}}
+    }
+    None => {}
+  }
   Ok(())
 }
 

--- a/src/pipe/modules/i-raw/rawloader-c/lib.rs
+++ b/src/pipe/modules/i-raw/rawloader-c/lib.rs
@@ -34,12 +34,8 @@ pub struct c_rawimage {
   pub focal_length: f32,
   pub datetime    : [c_char;32],
 
-  pub dng_opcode_list_1     : *mut c_void,
-  pub dng_opcode_list_1_len : u32,
-  pub dng_opcode_list_2     : *mut c_void,
-  pub dng_opcode_list_2_len : u32,
-  pub dng_opcode_list_3     : *mut c_void,
-  pub dng_opcode_list_3_len : u32,
+  pub dng_opcode_lists     : [*mut c_void;3],
+  pub dng_opcode_lists_len : [u32;3],
 
   pub data_type   : u32,   // 0 means u16, 1 means f32
   pub cfa_off_x   : u32,
@@ -80,9 +76,9 @@ unsafe fn copy_metadata(path : &str, rawimg : *mut c_rawimage) -> Result<()>
   match md.exif.focal_length      { Some(v) => { (*rawimg).focal_length = v.try_into().ok().unwrap(); } None => {}}
   match md.exif.orientation       { Some(v) => { (*rawimg).orientation  = v as u32; } None => {}}
   match md.exif.create_date       { Some(d) => { copy_string(&d, &mut (*rawimg).datetime) } None => {}}
-  match md.exif.dng_opcode_list_1 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_list_1, &mut (*rawimg).dng_opcode_list_1_len) } None => {}}
-  match md.exif.dng_opcode_list_2 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_list_2, &mut (*rawimg).dng_opcode_list_2_len) } None => {}}
-  match md.exif.dng_opcode_list_3 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_list_3, &mut (*rawimg).dng_opcode_list_3_len) } None => {}}
+  match md.exif.dng_opcode_list_1 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_lists[0], &mut (*rawimg).dng_opcode_lists_len[0]) } None => {}}
+  match md.exif.dng_opcode_list_2 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_lists[1], &mut (*rawimg).dng_opcode_lists_len[1]) } None => {}}
+  match md.exif.dng_opcode_list_3 { Some(v) => { data_to_c(&v, &mut (*rawimg).dng_opcode_lists[2], &mut (*rawimg).dng_opcode_lists_len[2]) } None => {}}
   Ok(())
 }
 

--- a/src/pipe/modules/i-raw/rawloader-c/rawloader.h
+++ b/src/pipe/modules/i-raw/rawloader-c/rawloader.h
@@ -22,6 +22,12 @@ typedef struct rawimage_t
   float    aperture;
   float    focal_length;
   char     datetime[32];
+  uint8_t *dng_opcode_list_1;
+  uint32_t dng_opcode_list_1_len;
+  uint8_t *dng_opcode_list_2;
+  uint32_t dng_opcode_list_2_len;
+  uint8_t *dng_opcode_list_3;
+  uint32_t dng_opcode_list_3_len;
   uint32_t data_type; // 0 means u16, 1 means f32
   uint32_t cfa_off_x;
   uint32_t cfa_off_y;

--- a/src/pipe/modules/i-raw/rawloader-c/rawloader.h
+++ b/src/pipe/modules/i-raw/rawloader-c/rawloader.h
@@ -22,12 +22,8 @@ typedef struct rawimage_t
   float    aperture;
   float    focal_length;
   char     datetime[32];
-  uint8_t *dng_opcode_list_1;
-  uint32_t dng_opcode_list_1_len;
-  uint8_t *dng_opcode_list_2;
-  uint32_t dng_opcode_list_2_len;
-  uint8_t *dng_opcode_list_3;
-  uint32_t dng_opcode_list_3_len;
+  uint8_t *dng_opcode_lists[3];
+  uint32_t dng_opcode_lists_len[3];
   uint32_t data_type; // 0 means u16, 1 means f32
   uint32_t cfa_off_x;
   uint32_t cfa_off_y;


### PR DESCRIPTION
I have been experimenting with adding support for [DNG Opcode List](https://helpx.adobe.com/content/dam/help/en/photoshop/pdf/DNG_Spec_1_7_1_0.pdf) processing.

These opcode lists can be used for operations like:

- Color shading correction (needed for most smartphone cameras)
- Vignetting correction
- Distortion and CA correction
- Marking dead pixels or PDAF pixels
- Applying a gamma curve for lossy 8 bit raws

The way the DNG spec defines these is very general - in theory there can be any number of opcodes, in any opcode list, applied to any region of the image. But any specific camera will typically only use one or two, consistently for all images it outputs. It isn't really necessary to support any arbitrary combination of opcodes, just the cases that do appear in images from supported cameras.

This PR will get the opcodes with exiv2 when using rawspeed. It can also get the opcodes using rawler, but only with [my branch](https://github.com/dnglab/dnglab/pull/398) which makes the opcodes available. Either way it decodes the opcodes into C structs that are easy to access. I added them to dt_image_params_t but maybe would be better to use the new dt_image_metadata_t linked list?

So far I have only added support for the GainMap opcode in OpcodeList2 (pre-demosaic), equivalent to [this in darktable](https://github.com/darktable-org/darktable/pull/10289).

I'm not sure about the best way to add this processing to a vkdt graph. Here I have created a new module 'dngop2' which would apply all OpcodeList2 processing, and there could be a similar module dngop3 for post-demosaic. It goes immediately after denoise because it needs the black/white point applied to rescale to (0,1), but this isn't exactly correct because it is supposed to operate on the full image prior to the crop that is also applied in denoise. Within the module it would add a node for each opcode in the list, or be a no-op for an image that has no opcodes. This could be added to the generic default graph for raw images or a dng specific graph. But if it just internally applies all the opcodes automatically it doesn't give the end user much control.

Another possibility would be to create a module for each individual opcode. This way, an expert end user who knows which opcodes their camera uses could manually create a graph for that camera which has the opcodes in the right place. An external script could take a dng file and the default graph, and create a modified graph with the opcode modules for that file added. Or a feature could be added to vkdt to automatically add the opcode modules to the graph.