### PR TITLE
Correct way to determine stats on remote filesystems 

### DIFF
--- a/src/core/fs.h
+++ b/src/core/fs.h
@@ -280,7 +280,19 @@ static inline int fs_islnk(const char *dirname, const struct dirent *e)
 #warning "port me!"
   return 0;
 #else
-  return e->d_type == DT_LNK;
+  if (e->d_type == DT_LNK) {
+    return 1;
+  }
+  else if (e->d_type == DT_UNKNOWN) {
+    char buf[512];
+    strcpy(buf, dirname);
+    strcat(buf, "/");
+    strcat(buf, e->d_name);
+    return fs_islnk_file(buf);
+  }
+  else {
+    return 0;
+  }
 #endif
 }
 
@@ -306,7 +318,19 @@ static inline int fs_isreg(const char *dirname, const struct dirent *e)
   _stat64(filename, &buf);
   return (buf.st_mode & _S_IFREG) != 0;
 #else
-  return e->d_type == DT_REG;
+  if (e->d_type == DT_REG) {
+    return 1;
+  }
+  else if (e->d_type == DT_UNKNOWN) {
+    char buf[512];
+    strcpy(buf, dirname);
+    strcat(buf, "/");
+    strcat(buf, e->d_name);
+    return fs_isreg_file(buf);
+  }
+  else {
+    return 0;
+  }
 #endif
 }
 


### PR DESCRIPTION
I have remote file storage mounted with nfs. 

For some files dirent reported DT_UNKNOWN type.

As mentioned here [stackoverflow article](https://stackoverflow.com/questions/47078417/readdir-returning-dirent-with-d-type-dt-unknown-for-directories-and) we need to call (l)stat manually for that systems.

I've added this ability. Please check if it is okey.

P.S. I'm not a pro in C, so if you know how to rewrite good - pls rewrite.