### PR TITLE
fix some macos runtime and compile time warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.a
 *ctooltips
 *ptooltips
+*.dSYM/
 cscope.out
 built/
 src/core/version.h

--- a/bin/config.mk.defaults.osx
+++ b/bin/config.mk.defaults.osx
@@ -68,8 +68,8 @@ export VKDT_USE_MCRAW
 FFMPEG_VERSION=$(shell ffmpeg -version | head -1 | cut -f 3 -d' ' | cut -d. -f1)
 VKDT_USE_FFMPEG=$(eval VKDT_USE_FFMPEG := $$(shell [ $(FFMPEG_VERSION) -gt 5 ] && echo 1 || echo 0))
 export VKDT_USE_FFMPEG
-VKDT_AV_CFLAGS=$(eval VKDT_AV_CFLAGS := $$(shell pkg-config --cflags libavformat --cflags libavcodec --cflags libswresample))$(VKDT_AV_CFLAGS)
-VKDT_AV_LDFLAGS=$(eval VKDT_AV_LDFLAGS := $$(shell pkg-config --libs libavformat --libs libavcodec --libs libswresample))$(VKDT_AV_LDFLAGS)
+VKDT_AV_CFLAGS=$(eval VKDT_AV_CFLAGS := $$(shell pkg-config --cflags libavformat --cflags libavcodec --cflags libavutil --cflags libswresample))$(VKDT_AV_CFLAGS)
+VKDT_AV_LDFLAGS=$(eval VKDT_AV_LDFLAGS := $$(shell pkg-config --libs libavformat --libs libavcodec --libs libavutil --libs libswresample))$(VKDT_AV_LDFLAGS)
 export VKDT_AV_CFLAGS VKDT_AV_LDFLAGS
 
 # where to find glfw for the gui:
@@ -108,7 +108,7 @@ GLSLC_FLAGS=--target-env vulkan1.2
 # GLSLC_FLAGS=--target-env=vulkan1.2
 
 # optimised flags, you may want to use -march=x86-64 for distro builds:
-OPT_CFLAGS=-Wall -pipe -O3 -march=x86-64 -DNDEBUG
+OPT_CFLAGS=-Werror -Wall -pipe -O3 -march=$(shell arch) -DNDEBUG
 OPT_LDFLAGS=
 AR=ar
 DYNAMIC=-rdynamic -fvisibility=hidden

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -6,14 +6,18 @@
 #include <sys/time.h>
 // some random helpers
 
+#ifndef MIN
 #define MIN(a,b) \
 ({ __typeof__ (a) _a = (a); \
    __typeof__ (b) _b = (b); \
    _a < _b ? _a : _b; })
+#endif //MIN
+#ifndef MAX
 #define MAX(a,b) \
 ({ __typeof__ (a) _a = (a); \
    __typeof__ (b) _b = (b); \
    _a > _b ? _a : _b; })
+#endif //MAX
 #define CLAMP(a,m,M) (MIN(MAX((a), (m)), (M)))
 
 // allocates, copies the old data, frees the old buffer p.

--- a/src/db/thumbnails.c
+++ b/src/db/thumbnails.c
@@ -136,6 +136,7 @@ dt_thumbnails_init(
   }};
 
   VkDescriptorPoolCreateInfo pool_info = {
+    .flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT,
     .sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
     .poolSizeCount = LENGTH(pool_sizes),
     .pPoolSizes    = pool_sizes,
@@ -151,6 +152,7 @@ dt_thumbnails_init(
     .pImmutableSamplers = 0,
   };
   VkDescriptorSetLayoutCreateInfo dset_layout_info = {
+    .flags        = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT,
     .sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
     .bindingCount = 1,
     .pBindings    = &binding,

--- a/src/gui/nuklear_glfw_vulkan.h
+++ b/src/gui/nuklear_glfw_vulkan.h
@@ -251,6 +251,7 @@ NK_INTERN VkResult nk_glfw3_create_font_descriptor_pool()
     .descriptorCount = 1,
   };
   VkDescriptorPoolCreateInfo pool_info = {
+    .flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT,
     .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
     .poolSizeCount = 1,
     .pPoolSizes = &pool_sizes,
@@ -268,6 +269,7 @@ NK_INTERN VkResult nk_glfw3_create_descriptor_pool(struct nk_glfw_device *dev)
     .descriptorCount = 1,
   };
   VkDescriptorPoolCreateInfo pool_info = {
+    .flags = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT,
     .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
     .poolSizeCount = 1,
     .pPoolSizes = &pool_sizes,
@@ -287,6 +289,7 @@ nk_glfw3_create_uniform_descriptor_set_layout(struct nk_glfw_device *dev)
     .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
   };
   VkDescriptorSetLayoutCreateInfo descriptor_set_info = {
+    .flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT,
     .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
     .bindingCount = 1,
     .pBindings = &binding,
@@ -340,6 +343,7 @@ nk_glfw3_create_font_dset()
     .stageFlags = VK_SHADER_STAGE_ALL,
   };
   VkDescriptorSetLayoutCreateInfo descriptor_set_info = {
+    .flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT,
     .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
     .bindingCount = 1,
     .pBindings = &binding,
@@ -749,8 +753,8 @@ nk_glfw3_device_upload_atlas(
 
     vkDestroyFence(glfw.logical_device, fence, NULL);
 
-    vkFreeMemory(glfw.logical_device, staging_buffer.memory, NULL);
     vkDestroyBuffer(glfw.logical_device, staging_buffer.buffer, NULL);
+    vkFreeMemory(glfw.logical_device, staging_buffer.memory, NULL);
 
     memset(&image_view_info, 0, sizeof(VkImageViewCreateInfo));
     image_view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -809,13 +813,13 @@ NK_API void nk_glfw3_device_destroy(struct nk_glfw_device *dev)
   vkUnmapMemory(glfw.logical_device, dev->index_memory);
   vkUnmapMemory(glfw.logical_device, dev->uniform_memory);
 
-  vkFreeMemory(glfw.logical_device, dev->vertex_memory, NULL);
-  vkFreeMemory(glfw.logical_device, dev->index_memory, NULL);
-  vkFreeMemory(glfw.logical_device, dev->uniform_memory, NULL);
-
   vkDestroyBuffer(glfw.logical_device, dev->vertex_buffer, NULL);
   vkDestroyBuffer(glfw.logical_device, dev->index_buffer, NULL);
   vkDestroyBuffer(glfw.logical_device, dev->uniform_buffer, NULL);
+
+  vkFreeMemory(glfw.logical_device, dev->vertex_memory, NULL);
+  vkFreeMemory(glfw.logical_device, dev->index_memory, NULL);
+  vkFreeMemory(glfw.logical_device, dev->uniform_memory, NULL);
 
   nk_buffer_free(&dev->cmds);
 }
@@ -1261,13 +1265,13 @@ nk_glfw3_mouse_button_callback(
   }
 
 #ifdef __APPLE__
-  if (button == GLFW_MOUSE_BUTTON_LEFT && ((mods & GLFW_MODS_CONTROL) == 0))
+  if (button == GLFW_MOUSE_BUTTON_LEFT && ((mods & GLFW_MOD_CONTROL) == 0))
 #else
   if (button == GLFW_MOUSE_BUTTON_LEFT)
 #endif
     nk_input_button(ctx, NK_BUTTON_LEFT, (int)x, (int)y, action == GLFW_PRESS);
 #ifdef __APPLE__
-  if (button == GLFW_MOUSE_BUTTON_LEFT && (mods & GLFW_MODS_CONTROL)
+  if (button == GLFW_MOUSE_BUTTON_LEFT && ((mods & GLFW_MOD_CONTROL) == 0))
 #else
   if (button == GLFW_MOUSE_BUTTON_MIDDLE)
 #endif

--- a/src/pipe/graph-run-modules.h
+++ b/src/pipe/graph-run-modules.h
@@ -418,6 +418,7 @@ dt_graph_run_modules(
         .stageFlags = VK_SHADER_STAGE_ALL,
       }};
       VkDescriptorSetLayoutCreateInfo dset_layout_info = {
+        .flags        = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT,
         .sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
         .bindingCount = 2,
         .pBindings    = bindings,

--- a/src/pipe/graph-run-nodes-allocate.h
+++ b/src/pipe/graph-run-nodes-allocate.h
@@ -836,6 +836,7 @@ alloc_outputs(dt_graph_t *graph, dt_node_t *node)
   {
     // create a descriptor set layout
     VkDescriptorSetLayoutCreateInfo dset_layout_info = {
+      .flags        = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT,
       .sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
       .bindingCount = node->num_connectors,
       .pBindings    = bindings,
@@ -1423,6 +1424,7 @@ dt_graph_run_nodes_allocate(
       }};
 
       VkDescriptorPoolCreateInfo pool_info = {
+        .flags         = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT,
         .sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
         .poolSizeCount = LENGTH(pool_sizes),
         .pPoolSizes    = pool_sizes,

--- a/src/pipe/modules/i-hdr/rgbe.c
+++ b/src/pipe/modules/i-hdr/rgbe.c
@@ -4,7 +4,7 @@
 
 #include "rgbe.h"
 #include <math.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 

--- a/src/pipe/modules/i-obj/obj.h
+++ b/src/pipe/modules/i-obj/obj.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <float.h>
+#include <inttypes.h>
 // simple header to parse a wavefront obj file into raw geo triangles
 
 typedef struct geo_obj_face_t
@@ -38,7 +39,7 @@ geo_obj_load_lists(
   {
     if(!strncmp(line, "vn ", 3))
     {
-      if(ni >= num_normals) fprintf(stderr, "obj has fewer normals than expected (%lu)\n", num_normals);
+      if(ni >= num_normals) fprintf(stderr, "obj has fewer normals than expected (%" PRIu64 ")\n", num_normals);
       assert(ni < num_normals);
       const int cnt = sscanf(line, "vn %f %f %f", n + 3*ni, n+3*ni+1, n+3*ni+2);
       if(cnt == 3) ni++;
@@ -46,7 +47,7 @@ geo_obj_load_lists(
     }
     else if(vt && !strncmp(line, "vt ", 3))
     {
-      if(ti >= num_vts) fprintf(stderr, "obj has fewer texture coordinates than expected (%lu)\n", num_vts);
+      if(ti >= num_vts) fprintf(stderr, "obj has fewer texture coordinates than expected (%" PRIu64 ")\n", num_vts);
       assert(ti < num_vts);
       const int cnt = sscanf(line, "vt %f %f", vt + 2*ti, vt+2*ti+1);
       if(cnt == 2) ti++;
@@ -54,7 +55,7 @@ geo_obj_load_lists(
     }
     else if(!strncmp(line, "v ", 2))
     {
-      if(vi >= num_verts) fprintf(stderr, "obj has fewer vertices than expected (%lu)\n", num_verts);
+      if(vi >= num_verts) fprintf(stderr, "obj has fewer vertices than expected (%" PRIu64 ")\n", num_verts);
       assert(vi < num_verts);
       const int cnt = sscanf(line, "v %f %f %f", v + 3*vi, v+3*vi+1, v+3*vi+2);
       for(int i=0;i<3;i++) aabb[i+0] = MIN(aabb[i+0], v[3*vi+i]);

--- a/src/pipe/raytrace.c
+++ b/src/pipe/raytrace.c
@@ -209,6 +209,7 @@ dt_raytrace_graph_init(
       .stageFlags      = VK_SHADER_STAGE_ALL,
     }};
     VkDescriptorSetLayoutCreateInfo dset_layout_info = {
+      .flags        = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT,
       .sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
       .bindingCount = 2,
       .pBindings    = bindings,

--- a/src/qvk/qvk.c
+++ b/src/qvk/qvk.c
@@ -381,6 +381,8 @@ qvk_init(const char *preferred_device_name, int preferred_device_id, int window)
 #endif
   if(window) requested_device_extensions[len++] = VK_KHR_SWAPCHAIN_EXTENSION_NAME;
 
+  requested_device_extensions[len++] = VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME;
+
   VkDeviceCreateInfo dev_create_info = {
     .sType                   = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
     .pNext                   = &device_features,


### PR DESCRIPTION
fixes compile time error:
```
gui/nuklear_glfw_vulkan.h:1264:52: error: use of undeclared identifier 'GLFW_MODS_CONTROL'
 1264 |   if (button == GLFW_MOUSE_BUTTON_LEFT && ((mods & GLFW_MODS_CONTROL) == 0))
```
also, removes some compile time warnings (not all).

removes runtime warnings about exceeding sampler binding count like that:
```
[qvk] validation layer: Validation Error: [ VUID-VkPipelineLayoutCreateInfo-descriptorType-03016 ] | MessageID = 0x56816e61 | vkCreatePipelineLayout():  max per-stage sampler bindings count (33) exceeds device maxPerStageDescriptorSamplers limit (16).
The Vulkan spec states: The total number of descriptors in descriptor set layouts created without the VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT bit set with a descriptorType of VK_DESCRIPTOR_TYPE_SAMPLER and VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER accessible to any given shader stage across all elements of pSetLayouts must be less than or equal to VkPhysicalDeviceLimits::maxPerStageDescriptorSamplers (https://vulkan.lunarg.com/doc/view/1.3.296.0/mac/1.3-extensions/vkspec.html#VUID-VkPipelineLayoutCreateInfo-descriptorType-03016)
```

removes runtime warnings about freeing memory with buffers bound:
```
CHASSIS(WARN / SPEC): msgNum: 1936111581 - Validation Warning: [ CHASSIS ] Object 0: handle = 0xab64de0000000020, type = VK_OBJECT_TYPE_BUFFER; Object 1: handle = 0xc4f3070000000021, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x7366b7dd | vkFreeMemory():  VK Object VkBuffer 0xab64de0000000020[] still has a reference to mem obj VkDeviceMemory 0xc4f3070000000021[].
    Objects: 2
        [0] 0xab64de0000000020, type: 9, name: NULL
        [1] 0xc4f3070000000021, type: 8, name: NULL
```
