### PR TITLE
Do not check for queue transfer bit

### DIFF
--- a/src/pipe/modules/blend/flat.mk
+++ b/src/pipe/modules/blend/flat.mk
@@ -1,2 +1,3 @@
+MOD_LDFLAGS=-lm
 pipe/modules/blend/up.comp.spv: pipe/modules/blend/transform.glsl
 pipe/modules/blend/down.comp.spv: pipe/modules/blend/transform.glsl

--- a/src/pipe/modules/colour/flat.mk
+++ b/src/pipe/modules/colour/flat.mk
@@ -1,2 +1,3 @@
+MOD_LDFLAGS=-lm
 pipe/modules/colour/main.comp.spv: pipe/modules/colour/main-impl.glsl
 pipe/modules/colour/main-.comp.spv: pipe/modules/colour/main-impl.glsl

--- a/src/pipe/modules/i-hdr/flat.mk
+++ b/src/pipe/modules/i-hdr/flat.mk
@@ -1,0 +1,1 @@
+MOD_LDFLAGS=-lm

--- a/src/pipe/modules/i-raw/flat.mk
+++ b/src/pipe/modules/i-raw/flat.mk
@@ -44,7 +44,7 @@ endif # end rawspeed
 
 # use rawloader
 ifeq ($(VKDT_USE_RAWINPUT),2)
-MOD_LDFLAGS=pipe/modules/i-raw/rawloader-c/target/release/librawloader.a
+MOD_LDFLAGS=pipe/modules/i-raw/rawloader-c/target/release/librawloader.a -lm
 ifeq ($(OS),Windows_NT)
 MOD_LDFLAGS+=-lws2_32 -lntdll -lbcrypt -lkernel32 -ladvapi32
 endif

--- a/src/qvk/qvk.c
+++ b/src/qvk/qvk.c
@@ -273,8 +273,7 @@ qvk_init(const char *preferred_device_name, int preferred_device_id, int window)
   for(int i = 0; i < num_queue_families; i++)
   {
     if((queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) &&
-       (queue_families[i].queueFlags & VK_QUEUE_COMPUTE_BIT) &&
-       (queue_families[i].queueFlags & VK_QUEUE_TRANSFER_BIT))
+       (queue_families[i].queueFlags & VK_QUEUE_COMPUTE_BIT))
     {
       queue_cnt = queue_families[i].queueCount;
       queue_family_index = i;


### PR DESCRIPTION
Do not check for VK_QUEUE_TRANSFER_BIT which might not be set.

According to https://registry.khronos.org/vulkan/specs/latest/man/html/VkQueueFlagBits.html -
All commands that are allowed on a queue that supports transfer operations are also allowed on a queue that supports either graphics or compute operations. Thus, if the capabilities of a queue family include VK_QUEUE_GRAPHICS_BIT or VK_QUEUE_COMPUTE_BIT, then reporting the VK_QUEUE_TRANSFER_BIT capability separately for that queue family is optional.

Also add -lm to ldflags for a few modules which use math.h.