### PR TITLE
add nix devShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "raw photography workflow that sucks less";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, ... }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShell = with pkgs; mkShell {
+          inputsFrom = [ pkgs.vkdt ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
FIrst part of #167, this PR adds a minimal nix flake that allows nix users to enter a shell with all of this project's dependencies installed (pulled from the current package in nixpkgs). This allows for easy develop. You can now compile vkdt on a bare nix install by simply running `nix develop` and then `cd bin; make`. This provides a nice isolated dev environment for both linux and macOS nix users, running on both x86 and arm:
```
❯ nix flake show
git+file:///home/will/Projects/vkdt?ref=refs/heads/master&rev=c4c3936fc5dcdac4f4459e1d2094bcc961209e46
└───devShell
    ├───aarch64-darwin omitted (use '--all-systems' to show)
    ├───aarch64-linux omitted (use '--all-systems' to show)
    ├───x86_64-darwin omitted (use '--all-systems' to show)
    └───x86_64-linux: development environment 'nix-shell'
```

A follow-up would be to allow nix users to install the package through the flake as well, to ensure they get access to the bleeding edge version of vkdt. From here, we could also [incorporate basic compilation / syntax checks that PRs would need to pass prior to approval through a nix environment managed by the flake](https://determinate.systems/posts/nix-github-actions/) (if desired).

Caveats:
- If any dependencies are added to vkdt, we will need to include them in the flake until a new release is cut, as the flake just copies the dependencies from the currently released vkdt version found in the nix package repo. Considering the suckless goal of this project I figure this won't be a huge issue, but wanted to bring awareness to it. I would be more than happy to update the flake upon any extra dependencies being added
- Flakes rely on a lock file to lock down the versions of the flake's dependencies. I can include a github action to update this lock file periodically (bi weekly, monthly?) to reduce maintenance burden