### PR TITLE
win64: introduce utf8 support for windows, following @kmilos' pointers

### DIFF
--- a/src/core/flat.mk
+++ b/src/core/flat.mk
@@ -7,3 +7,9 @@ CORE_H=core/colour.h \
        core/threads.h
 CORE_CFLAGS=
 CORE_LDFLAGS=-pthread -ldl
+
+ifeq ($(OS),Windows_NT)
+CORE_O+=core/utf8_manifest.o
+core/utf8_manifest.o: core/utf8.rc
+	windres -O coff $< $@
+endif

--- a/src/core/utf8.rc
+++ b/src/core/utf8.rc
@@ -1,0 +1,12 @@
+/* CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST */
+1 24
+BEGIN
+"<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>\n"
+"<assembly manifestVersion=""1.0"" xmlns=""urn:schemas-microsoft-com:asm.v1"">\n"
+"  <application>\n"
+"    <windowsSettings>\n"
+"      <activeCodePage xmlns=""http://schemas.microsoft.com/SMI/2019/WindowsSettings"">UTF-8</activeCodePage>\n"
+"    </windowsSettings>\n"
+"  </application>\n"
+"</assembly>\n"
+END


### PR DESCRIPTION
pull requesting a first completely untested version of including the utf8 manifest into windows builds. i don't have windows 10, so i'm hoping this can receive some testing/ci here.