### PR TITLE
Fixed exiftool not copying data from paths with spaces

### DIFF
--- a/bin/exiftool
+++ b/bin/exiftool
@@ -1,3 +1,3 @@
 #!/bin/sh
 # this is just a trampoline here to find exiftool in PATH via popen()
-exiftool $@
+exiftool "$@"

--- a/src/pipe/modules/o-jpg/main.c
+++ b/src/pipe/modules/o-jpg/main.c
@@ -197,7 +197,7 @@ void write_sink(
 
     // maybe route this string in via o-jpg params (beware of the ':' and then dt_sanitize_user_string + dt_strexpand it)
     char cmd[1024];
-    if(sizeof(cmd) <= snprintf(cmd, sizeof(cmd), "%s/exiftool -TagsFromFile %s \"-all:all>all:all\" -Software=\"vkdt\" -ModifyDate=\"now\" -*orientation*= -overwrite_original %s",
+    if(sizeof(cmd) <= snprintf(cmd, sizeof(cmd), "%s/exiftool -TagsFromFile \"%s\" \"-all:all>all:all\" -Software=\"vkdt\" -ModifyDate=\"now\" -*orientation*= -overwrite_original \"%s\"",
           dt_pipe.basedir, src_filename, filename)) return;
     // TODO find a way to access the model-based time offset in the db (cli doesn't have a db).
     // then insert "-AllDates+=%s", timeoffset before the "now" above.


### PR DESCRIPTION
Added necessary quoting to properly copy exif data when the paths contain spaces.