### PR TITLE
gui: image widget zoom to mouse pos

### DIFF
--- a/src/gui/widget_image.h
+++ b/src/gui/widget_image.h
@@ -316,7 +316,8 @@ dt_image_events(struct nk_context *ctx, dt_image_widget_t *w, int hovered, int m
     if(yoff != 0)
     { // mouse wheel (yoff is the input)
       ctx->input.mouse.scroll_delta.y = 0;
-      w->scale *= yoff > 0.0f ? 1.1f : 0.9f;
+      const float factor = yoff > 0.0f ? 1.1f : 0.9f;
+      dt_image_zoom_at(w, mpos.x, mpos.y, factor);
     }
   }
   else

--- a/src/gui/widget_image_util.h
+++ b/src/gui/widget_image_util.h
@@ -82,3 +82,26 @@ dt_image_zoom(
   w->look_at_x += -img1[0]+img[0];
   w->look_at_y += -img1[1]+img[1];
 }
+
+// zoom by a multiplicative factor centered at (x,y) in screen coordinates
+static inline void
+dt_image_zoom_at(
+    dt_image_widget_t *w,
+    float              x,
+    float              y,
+    float              factor)
+{
+  float view[2] = {x,y}, img[2];
+  dt_image_from_view(w, view, img);
+
+  float scale_fit = MIN(w->win_w/w->wd, w->win_h/w->ht);
+  float min_scale = 1.0f; // zoom-to-fit
+  float max_scale = 8.0f * (1.0f/scale_fit);
+
+  w->scale = CLAMP(w->scale * factor, min_scale, max_scale);
+
+  float img1[2];
+  dt_image_from_view(w, view, img1);
+  w->look_at_x += -img1[0] + img[0];
+  w->look_at_y += -img1[1] + img[1];
+}


### PR DESCRIPTION
This PR changes the zoom of the image origin to be at the mouse coordinates. Let me know if you prefer the centered zoom and maybe this can be toggled in preferences