### PR TITLE
qvk: rename config present_mode to vk_present_mode

### DIFF
--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -390,7 +390,7 @@ out:;
   VkPresentModeKHR *avail_present_modes = alloca(sizeof(VkPresentModeKHR) * num_present_modes);
   vkGetPhysicalDeviceSurfacePresentModesKHR(qvk.physical_device, win->surface, &num_present_modes, avail_present_modes);
 
-  // present mode selection: allow user to pick via config `gui/present_mode`:
+  // present mode selection: allow user to pick via config `gui/vk_present_mode`:
   // 0 = FIFO (default, vsync), 1 = MAILBOX (low-latency vsync if available), 2 = IMMEDIATE (no vsync, tearing)
   int pref = dt_rc_get_int(&vkdt.rc, "gui/vk_present_mode", 0);
   win->present_mode = VK_PRESENT_MODE_FIFO_KHR; // safe default
@@ -398,7 +398,7 @@ out:;
   {
     for(uint32_t i=0;i<num_present_modes;i++) if(avail_present_modes[i] == VK_PRESENT_MODE_MAILBOX_KHR) { win->present_mode = VK_PRESENT_MODE_MAILBOX_KHR; break; }
     if(win->present_mode == VK_PRESENT_MODE_MAILBOX_KHR)
-      dt_log(s_log_qvk, "present mode: MAILBOX (low-latency vsync)");
+      dt_log(s_log_qvk, "vulkan present mode: MAILBOX (low-latency vsync)");
     else
       dt_log(s_log_qvk, "MAILBOX not available, falling back to FIFO");
   }
@@ -406,13 +406,13 @@ out:;
   {
     for(uint32_t i=0;i<num_present_modes;i++) if(avail_present_modes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR) { win->present_mode = VK_PRESENT_MODE_IMMEDIATE_KHR; break; }
     if(win->present_mode == VK_PRESENT_MODE_IMMEDIATE_KHR)
-      dt_log(s_log_qvk, "present mode: IMMEDIATE (no vsync)");
+      dt_log(s_log_qvk, "vulkan present mode: IMMEDIATE (no vsync)");
     else
       dt_log(s_log_qvk, "IMMEDIATE not available, falling back to FIFO");
   }
   else
   {
-    dt_log(s_log_qvk, "present mode: FIFO (vsync)");
+    dt_log(s_log_qvk, "vulkan present mode: FIFO (vsync)");
   }
 
   VkExtent2D extent;


### PR DESCRIPTION
`present_mode` was too generic. I think this is more fitting.