### PR TITLE
Makefile refinements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,14 +93,14 @@ install-lib: install-mod Makefile src/core/version.h
 	cp -rfL src/gui/*.h $(VKDTINCDIR)/gui
 	cp -rfL src/core/*.h $(VKDTINCDIR)/core
 
-RELEASE_FILES=$(shell echo src/core/version.h; git ls-files --recurse-submodules)
+RELEASE_FILES=$(shell echo src/core/version.h; git ls-files --recurse-submodules 2>/dev/null)
 ifeq ($(VKDT_USE_RAWINPUT), 1)
-  RAWSPEED_DIR=$(shell ls -d src/pipe/modules/i-raw/rawspeed-*)
-  RELEASE_FILES+=$(shell cd $(RAWSPEED_DIR) && git ls-files | sed -e 's\#^\#$(RAWSPEED_DIR)/\#')
+  RAWSPEED_DIR=$(shell ls -d src/pipe/modules/i-raw/rawspeed-* 2>/dev/null)
+  RELEASE_FILES+=$(shell cd $(RAWSPEED_DIR) && git ls-files 2/dev/null | sed -e 's\#^\#$(RAWSPEED_DIR)/\#')
 endif
 ifeq ($(VKDT_USE_MCRAW), 1)
-  MCRAW_DIR=$(shell ls -d src/pipe/modules/i-mcraw/mcraw-*)
-  RELEASE_FILES+=$(shell cd $(MCRAW_DIR) && git ls-files | sed -e 's\#^\#$(MCRAW_DIR)/\#')
+  MCRAW_DIR=$(shell ls -d src/pipe/modules/i-mcraw/mcraw-* 2>/dev/null)
+  RELEASE_FILES+=$(shell cd $(MCRAW_DIR) && git ls-files 2>/dev/null | sed -e 's\#^\#$(MCRAW_DIR)/\#')
 endif
 ifeq ($(VKDT_USE_QUAKE), 1)
   RELEASE_FILES+=$(shell cd src/pipe/modules/quake/quakespasm; git ls-files | sed -e 's\#^\#src/pipe/modules/quake/quakespasm/\#')
@@ -147,18 +147,20 @@ distclean:
 	$(shell find . -name "*.o"   -exec rm {} \;)
 	$(shell find . -name "*.spv" -exec rm {} \;)
 	$(shell find . -name "*.so"  -exec rm {} \;)
-	rm -rf bin/vkdt bin/vkdt-fit bin/vkdt-cli bin/vkdt-mkssf bin/vkdt-mkclut bin/vkdt-lutinfo bin/vkdt-eval-profile bin/libvkdt.so
-	rm -rf src/macadam
-	rm -rf src/mkabney
-	rm -rf bin/data/*.lut
-	rm -rf bin/data/cameras.xml
+	rm -f bin/data/*.lut
+	rm -f bin/data/cameras.xml
 	rm -rf bin/modules
-	rm -rf src/macadam.lut
+	rm -f bin/config.mk
 	$(MAKE) -C src distclean
 
 uninstall-lib:
-	rm -rf $(VKDTLIBDIR)/libvkdt.so $(VKDTLIBDIR)/modules  $(VKDTLIBDIR)/data
-	rm -rf $(VKDTINCDIR)
+	rm -f $(VKDTLIBDIR)/libvkdt.so
+	rm -rf $(VKDTINCDIR)/ $(VKDTDIR)/
+
+uninstall-bin:
+	rm -f $(VKDTBIN)/vkdt $(VKDTBIN)/vkdt-cli
+
+uninstall: uninstall-lib uninstall-bin
 
 bin: Makefile
 	mkdir -p bin/data
@@ -167,6 +169,9 @@ ifeq ($(OS),Windows_NT)
 else
 	ln -sf ../src/pipe/modules bin/
 endif
+
+# Avoid failing on missing custom config
+bin/config.mk:
 
 info: Makefile bin/config.mk
 ifeq ($(VKDT_USE_RAWINPUT), 0)

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all debug sanitize sanitize-thread cli reload-shaders clean
+.PHONY: all debug sanitize sanitize-thread cli reload-shaders clean distclean
 
 all:
 	$(MAKE) -C .. all
@@ -23,4 +23,6 @@ reload-shaders:
 
 clean:
 	$(MAKE) -C .. clean
-	rm -f vkdt vkdt-cli vkdt-fit vkdt-mkssf vkdt-mkclut vkdt-eval-profile vkdt-lutinfo libvkdt.so
+
+distclean:
+	$(MAKE) -C .. distclean

--- a/src/Makefile
+++ b/src/Makefile
@@ -58,7 +58,8 @@ include fit/flat.mk
 include tools/flat.mk
 
 clean: Makefile
-	rm -f ../bin/vkdt ../bin/vkdt-cli ../bin/vkdt-fit
+	rm -f ../bin/vkdt ../bin/vkdt-cli ../bin/vkdt-fit ../bin/vkdt-read-icc ../bin/vkdt-eval-profile ../bin/vkdt-lutinfo
+	rm -f ../bin/vkdt-mkclut ../bin/vkdt-mkssf
 	rm -f $(GUI_O) $(CORE_O) $(PIPE_O) $(SND_O) $(CLI_O) $(FIT_O) $(QVK_O) $(DB_O)
 	rm -f gui/shd.h
 	rm -f gui/shd/*.spv
@@ -68,6 +69,13 @@ clean: Makefile
 	rm -f pipe/modules/*/lib*.so
 	rm -f pipe/modules/*/*.spv
 	rm -f pipe/modules/*/{ctooltips,ptooltips}
+
+distclean: clean
+	rm -f macadam mkabney mkspectra macadam.lut
+	rm -rf pipe/modules/i-raw/rawloader-c/target
+	rm -rf pipe/modules/i-mcraw/mcraw-*
+	rm -rf pipe/modules/i-raw/rawspeed-*
+	rm -f core/version.h
 
 # GNU_SOURCE for sched_affinity
 CFLAGS?=-Wall -pipe -I. -D_GNU_SOURCE -std=c11


### PR DESCRIPTION
* More complete `clean`/`distclean` targets
  * Remove the `config.mk` in `distclean`. I think it matches what a `distclean` is expected to do, but it may be surprising to users.  
* Add an `uninstall` target
* Make `info` target work without a custom build config (and before the first build, which currently displayed errors due to git/ls commands running on non-existing dirs)
