### PR TITLE
Correct sorting of directories and files in filebrowser

### DIFF
--- a/src/gui/main.c
+++ b/src/gui/main.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <math.h>
+#include <locale.h>
 
 dt_gui_t vkdt = {0};
 
@@ -194,6 +195,7 @@ int main(int argc, char *argv[])
   dt_pipe_global_init();
   threads_global_init();
   dt_set_signal_handlers();
+  setlocale(LC_COLLATE, "");
 
   if(dt_gui_init())
   {

--- a/src/gui/widget_filebrowser.h
+++ b/src/gui/widget_filebrowser.h
@@ -49,9 +49,9 @@ static int dt_filebrowser_sort_dir_first(const void *aa, const void *bb, void *c
   const struct dirent *a = (const struct dirent *)aa;
   const struct dirent *b = (const struct dirent *)bb;
   const char *cwd = (const char *)cw;
-  if( fs_isdir(cwd, a) && !fs_isdir(cwd, b)) return 0;
+  if( fs_isdir(cwd, a) && !fs_isdir(cwd, b)) return -1;
   if(!fs_isdir(cwd, a) &&  fs_isdir(cwd, b)) return 1;
-  return strcmp(a->d_name, b->d_name);
+  return strcoll(a->d_name, b->d_name);
 }
 
 static int dt_filebrowser_filter_dir(const struct dirent *d, const char *cwd, const char *filter)


### PR DESCRIPTION
Sorting was random at least on macOS
- directories were not sorted at all
- directories were mixed with files (not "dir first")
- files were grouped (files with uppercase letters first, then lowercase)

As far as I understand, the same issues should be present on the other platforms, maybe a bit less visible.