### PR TITLE
Enable development with nix flake + add exiftool

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
             ];
 
             buildInputs = with pkgs; [
+              exiftool
               alsa-lib
               ffmpeg
               glfw
@@ -77,6 +78,8 @@
 
         devShells.default = pkgs.mkShell {
           inputsFrom = [ self.packages.${system}.vkdt-git ];
+          buildInputs = with pkgs; [ gdb ];
+          VK_LAYER_PATH = "${pkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d";
         };
       }
     );


### PR DESCRIPTION
Debug builds require vulkan validation layers to be present at VK_LAYER_PATH.  Also add gdb to the devShell for debugging and exiftool to the package dependencies.