### PR TITLE
fix dynamic lod for sliders and drag keys

### DIFF
--- a/src/gui/render_darkroom.c
+++ b/src/gui/render_darkroom.c
@@ -416,6 +416,10 @@ void render_darkroom()
     return;
   }
 
+  if(vkdt.wstate.interact_end) dt_gui_set_lod(vkdt.wstate.lod_fine);
+  { static int prev_latched = 0;
+    if(dragkeys.latched != prev_latched) dt_gui_set_lod(dragkeys.latched ? vkdt.wstate.lod_interact : vkdt.wstate.lod_fine);
+    prev_latched = dragkeys.latched; }
   dt_radial_menu_dr(&vkdt.wstate.radial_menu_dr, bounds);
 
   static int resize_panel = 0;
@@ -894,7 +898,6 @@ void render_darkroom()
       dt_darkroom_activate_module(vkdt.wstate.pending_modid);
     vkdt.wstate.pending_modid = -1;
   }
-  // dt_gui_set_lod(dragkeys.latched ? vkdt.wstate.lod_interact : vkdt.wstate.lod_fine);
   gui.pgupdn = 0;  // reset rotary encoder knob counter
   gui.hotkey = -1; // reset hotkey, we worked on all we could
   dt_log(s_log_perf, "render_darkroom cpu:\t%8.3f ms", 1000.0*(dt_time() - clock_beg));


### PR DESCRIPTION
fixes #260

two bugs. the dragkey feature left a per-frame set_lod call at the end of render_darkroom which was resetting lod every frame, so sliders would drop to interact-lod for one frame and immediately snap back. the other one is that interact_end restoring lod_fine in render_darkroom.h is inside a hover check, so releasing a slider outside its bounds left the preview stuck at interact-lod.

fix is an unconditional interact_end restore before widget rendering, and latch transition detection for dragkeys. four lines.
