### PR TITLE
fix: chord menu should not grab modified hotkeys

### DIFF
--- a/src/gui/menu.h
+++ b/src/gui/menu.h
@@ -1049,7 +1049,8 @@ dt_menu_keyboard(
     hk_t      *hk,
     int        hk_cnt,
     int        key,
-    int        action)
+    int        action,
+    int        mods)
 {
   if(action != GLFW_PRESS && action != GLFW_REPEAT) return m->depth > 0 ? 1 : 0;
   // REPEAT only for navigation keys, not for selection/leader keys
@@ -1058,6 +1059,7 @@ dt_menu_keyboard(
   if(m->depth == 0)
   {
     if(is_repeat) return 0; // don't open menus on repeat
+    if(mods) return 0; // don't steal modified keys (e.g. ctrl+p)
     if(dt_gui_input_blocked()) return 0;
     for(int i = 0; i < m->cnt; i++)
     {

--- a/src/gui/render_darkroom.c
+++ b/src/gui/render_darkroom.c
@@ -232,7 +232,7 @@ darkroom_keyboard(GLFWwindow *window, int key, int scancode, int action, int mod
     return;
   }
 
-  int mr = dt_menu_keyboard(&darkroom_menu, hk_darkroom, hk_darkroom_cnt, key, action);
+  int mr = dt_menu_keyboard(&darkroom_menu, hk_darkroom, hk_darkroom_cnt, key, action, mods);
   if(mr == 1) return;
   if(mr < -1) { gui.hotkey = -(mr + 2); goto hotkey_dispatch; }
   if(dt_dragkey_keyboard(&dragkeys, key, action, mods)) return; // keyboard arm

--- a/src/gui/render_files.c
+++ b/src/gui/render_files.c
@@ -415,7 +415,7 @@ files_keyboard(GLFWwindow *window, int key, int scancode, int action, int mods)
     return hk_keyboard(hk_files, window, key, scancode, action, mods);
   if(dt_gui_input_blocked()) return;
   { // chord menu
-    int mr = dt_menu_keyboard(&files_menu, hk_files, sizeof(hk_files)/sizeof(hk_files[0]), key, action);
+    int mr = dt_menu_keyboard(&files_menu, hk_files, sizeof(hk_files)/sizeof(hk_files[0]), key, action, mods);
     if(mr == 1) return;
   }
   dt_filebrowser_widget_t *w = &filebrowser;

--- a/src/gui/render_lighttable.c
+++ b/src/gui/render_lighttable.c
@@ -93,7 +93,7 @@ lighttable_keyboard(GLFWwindow *w, int key, int scancode, int action, int mods)
   if(dt_gui_input_blocked()) return; // includes other popups
 
   { // chord menu
-    int mr = dt_menu_keyboard(&lighttable_menu, hk_lighttable, NK_LEN(hk_lighttable), key, action);
+    int mr = dt_menu_keyboard(&lighttable_menu, hk_lighttable, NK_LEN(hk_lighttable), key, action, mods);
     if(mr == 1) return;
     // note: menu-triggered hotkeys not yet wired for lighttable
   }

--- a/src/gui/render_nodes.c
+++ b/src/gui/render_nodes.c
@@ -316,7 +316,7 @@ void nodes_keyboard(GLFWwindow *window, int key, int scancode, int action, int m
     return hk_keyboard(hk_nodes, window, key, scancode, action, mods);
   if(dt_gui_input_blocked()) return;
   { // chord menu
-    int mr = dt_menu_keyboard(&nodes_menu, hk_nodes, sizeof(hk_nodes)/sizeof(hk_nodes[0]), key, action);
+    int mr = dt_menu_keyboard(&nodes_menu, hk_nodes, sizeof(hk_nodes)/sizeof(hk_nodes[0]), key, action, mods);
     if(mr == 1) return;
   }
   if(action == GLFW_PRESS && key == GLFW_KEY_ESCAPE)


### PR DESCRIPTION
fixes #259

when a modifier key is held, the chord menu now ignores the keypress instead of matching it as a leader key. so ctrl+p opens the preset picker instead of the 'p' submenu.
