### PR TITLE
grade: tune color wheel effect scaling and sensitivity

### DIFF
--- a/src/gui/render_darkroom.h
+++ b/src/gui/render_darkroom.h
@@ -567,7 +567,7 @@ render_darkroom_widget(int modid, int parid, int is_fav_menu)
         float dx = ctx->input.mouse.pos.x - ctx->input.mouse.prev.x;
         float dy = ctx->input.mouse.pos.y - ctx->input.mouse.prev.y;
         int shift = nk_input_is_key_down(&ctx->input, NK_KEY_SHIFT);
-        float sens = shift ? 0.1f : 0.01f;
+        float sens = shift ? 0.15f : 0.005f;
         float sx = dx / (radius * 2.0f) * sens;
         float sy = dy / (radius * 2.0f) * sens;
         // constrained so sum of R+G+B deltas stays 0 (chromaticity only)
@@ -577,7 +577,11 @@ render_darkroom_widget(int modid, int parid, int is_fav_menu)
         disp[2] +=  1.0f/3.0f * sy + inv_rt3 * sx;
         float lo = param->widget.min, hi = param->widget.max;
         if(lo < hi) for(int k = 0; k < 3; k++) disp[k] = CLAMP(def[k] + disp[k], lo, hi) - def[k];
-        // constrain displacement to keep visual dot within wheel boundary
+        // constrain displacement to keep visual dot within wheel boundary.
+        // the color wheel enforces R+G+B = const (pure chromaticity, no luminance).
+        // for an equilateral triangle in RGB space, max per-component displacement is ~0.31-0.47
+        // depending on direction. this is enforced in (wx,wy) hexagonal space with max_dist ≈ 0.476.
+        // params.ui ranges must not clip this geometric limit (keep min/max wider than ±0.31).
         float wx = rt32 * (disp[2] - disp[1]);
         float wy = -disp[0] + 0.5f * (disp[1] + disp[2]);
         float dist_sq = wx * wx + wy * wy;

--- a/src/gui/render_darkroom.h
+++ b/src/gui/render_darkroom.h
@@ -567,7 +567,7 @@ render_darkroom_widget(int modid, int parid, int is_fav_menu)
         float dx = ctx->input.mouse.pos.x - ctx->input.mouse.prev.x;
         float dy = ctx->input.mouse.pos.y - ctx->input.mouse.prev.y;
         int shift = nk_input_is_key_down(&ctx->input, NK_KEY_SHIFT);
-        float sens = shift ? 0.15f : 0.005f;
+        float sens = shift ? 0.1f : 0.01f;
         float sx = dx / (radius * 2.0f) * sens;
         float sy = dy / (radius * 2.0f) * sens;
         // constrained so sum of R+G+B deltas stays 0 (chromaticity only)
@@ -995,7 +995,7 @@ render_darkroom_widget(int modid, int parid, int is_fav_menu)
 
     // full manual control over parameter using the slider:
     RESETBLOCK
-    nk_tab_property(float, ctx, "#", -360.0f, val, 360.0f, 
+    nk_tab_property(float, ctx, "#", -360.0f, val, 360.0f,
           (360.0f)/100.0,
           (360.0f)/(0.6*vkdt.state.center_wd));
     if(*val != oldval) change = 1;
@@ -1503,7 +1503,7 @@ static inline void render_darkroom_widgets(
     ((struct nk_user_font *)ctx->style.font)->height = vkdt.style.fontsize;
     // bit of a crazy dance to avoid double accounting for clicks on combo boxes that just closed above us:
     const struct nk_input *in = (ctx->current->layout->flags & NK_WINDOW_ROM) ? 0 : &ctx->input;
-    if(in && nk_input_is_mouse_hovering_rect(in, box) && 
+    if(in && nk_input_is_mouse_hovering_rect(in, box) &&
         nk_input_has_mouse_click_in_button_rect(in, NK_BUTTON_LEFT, box) &&
         nk_input_is_mouse_pressed(in, NK_BUTTON_LEFT))
     {
@@ -1546,7 +1546,7 @@ static inline void render_darkroom_widgets(
   if(active) nk_style_pop_color(&vkdt.ctx);
   // bit of a crazy dance to avoid double accounting for clicks on combo boxes that just closed above us:
   const struct nk_input *in = (vkdt.ctx.current->layout->flags & NK_WINDOW_ROM) ? 0 : &ctx->input;
-  if(in && nk_input_is_mouse_hovering_rect(in, bound) && 
+  if(in && nk_input_is_mouse_hovering_rect(in, bound) &&
       nk_input_has_mouse_click_in_button_rect(in, NK_BUTTON_LEFT, bound) &&
       nk_input_is_mouse_pressed(in, NK_BUTTON_LEFT))
   {
@@ -1757,7 +1757,7 @@ render_darkroom_modals()
         }
         if(buf[s-1] == '\n') buf[s-1] = 0;
       }
-    
+
       const float row_height = vkdt.ctx.style.font->height + 2 * vkdt.ctx.style.tab.padding.y;
       if(ok == 0)
       {

--- a/src/pipe/modules/grade/main.comp
+++ b/src/pipe/modules/grade/main.comp
@@ -26,10 +26,11 @@ main()
 
   vec3 rgb = texelFetch(img_in, ipos, 0).rgb;
 
-  vec3 lift   = params.lift.rgb  + params.lift.a;
-  vec3 gamma  = max(params.gamma.rgb + params.gamma.a, vec3(1e-6));
-  vec3 gain   = max(params.gain.rgb  + params.gain.a,  vec3(0));
-  vec3 off    = params.off.rgb + params.off.a;
+  const float effect_scale = 0.01;
+  vec3 lift   = (params.lift.rgb  + params.lift.a) * effect_scale;
+  vec3 gamma  = max((params.gamma.rgb + params.gamma.a - 1.0) * effect_scale + 1.0, vec3(1e-6));
+  vec3 gain   = max((params.gain.rgb  + params.gain.a - 1.0) * effect_scale + 1.0, vec3(0));
+  vec3 off    = (params.off.rgb + params.off.a) * effect_scale;
 
   if(params.mode == 0)
   {

--- a/src/pipe/modules/grade/params.ui
+++ b/src/pipe/modules/grade/params.ui
@@ -1,7 +1,7 @@
-lift:colwheel:-0.5:0.5:-0.2:0.2
-gamma:colwheel:0.5:1.5:-0.1:0.1
-gain:colwheel:0.5:1.5:-0.1:0.1
-offset:colwheel:-0.5:0.5:-0.2:0.2
+lift:colwheel:-0.3:0.3:-0.2:0.2
+gamma:colwheel:0.7:1.3:-0.1:0.1
+gain:colwheel:0.7:1.3:-0.1:0.1
+offset:colwheel:-0.3:0.3:-0.2:0.2
 mode:combo:classic:zoned log
 group:mode:1
 sh_pivot:slider:0.0:1.0

--- a/src/pipe/modules/grade/params.ui
+++ b/src/pipe/modules/grade/params.ui
@@ -1,7 +1,7 @@
-lift:colwheel:-0.3:0.3:-0.2:0.2
-gamma:colwheel:0.7:1.3:-0.1:0.1
-gain:colwheel:0.7:1.3:-0.1:0.1
-offset:colwheel:-0.3:0.3:-0.2:0.2
+lift:colwheel:-0.317:0.317:-0.2:0.2
+gamma:colwheel:0.683:1.317:-0.1:0.1
+gain:colwheel:0.683:1.317:-0.1:0.1
+offset:colwheel:-0.317:0.317:-0.2:0.2
 mode:combo:classic:zoned log
 group:mode:1
 sh_pivot:slider:0.0:1.0

--- a/src/pipe/modules/grade/readme.md
+++ b/src/pipe/modules/grade/readme.md
@@ -29,6 +29,14 @@ see: ACES S-2016-001 : ACEScct --- A Quasi-Logarithmic Encoding of ACES Data for
   
 * `hi_pivot` in mode 1: controls midtone-to-highlight transition point. must be > sh_pivot.
 
+## color wheel constraints
+
+the GUI uses a color wheel widget for lift, gamma, gain, and offset. the wheel enforces a zero-sum constraint on RGB deltas: R + G + B = 0 (pure chromaticity, no luminance change). this constraint creates an equilateral triangle in RGB space.
+
+the maximum displacement any single component can achieve is **±0.317**, which occurs when one component is maximized and the other two balance it symmetrically. this geometric limit comes from the circular boundary of the wheel visualization in hexagonal coordinates.
+
+the parameter ranges are set to exactly this geometric maximum (±0.317 for lift/offset, ±0.683–1.317 for gamma/gain). this ensures the visual wheel range matches the achievable parameter range with no clipping or wasted space.
+
 ## connectors
 
 * `input` the display referred input image in zero/one range


### PR DESCRIPTION
Reduce effect to 1% of original strength via shader multiplicator, increase wheel drag sensitivity to maintain responsive control. Adjust colwheel ranges to match actual achievable limits from geometric constraint.