### PR TITLE
dragkeys saturation: use the sat slider in the colour module

### DIFF
--- a/bin/dragkeys/saturation
+++ b/bin/dragkeys/saturation
@@ -1,3 +1,3 @@
-# hold key and drag mouse to adjust chroma on film curve
+# hold key and drag mouse to adjust saturation in colour
 key:s
-filmcurv:01:chroma:0:0.002
+colour:01:sat:0:0.002


### PR DESCRIPTION
The drag key for saturation seems to use an old version of filmcurv with a chroma slider. Saturation must have moved to the colour module in the meantime, but the key file wasn't updated.