### PR TITLE
Fix crashes on devices that do not have VK_EXT_shader_64bit_indexing or VK_KHR_unified_image_layouts support

### DIFF
--- a/src/gui/nuklear_glfw_vulkan.h
+++ b/src/gui/nuklear_glfw_vulkan.h
@@ -520,7 +520,7 @@ nk_glfw3_create_pipeline(struct nk_glfw_device *dev)
     };
     VkGraphicsPipelineCreateInfo pipeline_info = {
       .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
-      .pNext = &pipeline2_info,
+      .pNext = qvk.shader64bit_indexing_supported ? (void*)&pipeline2_info : 0,
       .flags = 0,
       .stageCount = 2,
       .pStages = shader_stages,

--- a/src/pipe/graph-run-nodes-allocate.h
+++ b/src/pipe/graph-run-nodes-allocate.h
@@ -1063,7 +1063,7 @@ alloc_outputs(dt_graph_t *graph, dt_node_t *node)
       VkFormat attachment_fmt = dt_connector_vkformat(node->connector+drawn_connector);
       VkPipelineRenderingCreateInfo pipeline_create = {
         .sType                   = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO_KHR,
-        .pNext                   = &pipeline2_info,
+        .pNext                   = qvk.shader64bit_indexing_supported ? (void*)&pipeline2_info : 0,
         .colorAttachmentCount    = 1,
         .pColorAttachmentFormats = &attachment_fmt,
       };
@@ -1123,7 +1123,7 @@ alloc_outputs(dt_graph_t *graph, dt_node_t *node)
         .sType  = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
         .stage  = stage_info,
         .layout = node->pipeline_layout,
-        .pNext  = &pipeline2_info,
+        .pNext  = qvk.shader64bit_indexing_supported ? (void*)&pipeline2_info : 0,
       };
       QVKR(vkCreateComputePipelines(qvk.device, VK_NULL_HANDLE, 1, &pipeline_info, 0, &node->pipeline));
 

--- a/src/qvk/qvk.c
+++ b/src/qvk/qvk.c
@@ -221,6 +221,8 @@ qvk_init(const char *preferred_device_name, int preferred_device_id, int window,
 
   qvk.raytracing_supported = 0;
   qvk.subgroup_size_control_supported = 0;
+  qvk.shader64bit_indexing_supported = 0;
+  qvk.unified_image_layouts_supported = 0;
   int picked_device = -1;
   for(int i = 0; i < num_devices; i++)
   {
@@ -253,6 +255,8 @@ qvk_init(const char *preferred_device_name, int preferred_device_id, int window,
       qvk.float_atomics_supported = 0;
       qvk.coopmat_supported = 0;
       qvk.subgroup_size_control_supported = 0;
+      qvk.shader64bit_indexing_supported = 0;
+      qvk.unified_image_layouts_supported = 0;
       for(int k=0;k<num_ext;k++)
       {
         if (!strcmp(ext_properties[k].extensionName, VK_KHR_RAY_QUERY_EXTENSION_NAME))
@@ -263,6 +267,10 @@ qvk_init(const char *preferred_device_name, int preferred_device_id, int window,
           qvk.coopmat_supported = 1;
         else if (!strcmp(ext_properties[k].extensionName, VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME))
           qvk.subgroup_size_control_supported = 1;
+        else if (!strcmp(ext_properties[k].extensionName, VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME))
+          qvk.shader64bit_indexing_supported = 1;
+        else if (!strcmp(ext_properties[k].extensionName, VK_KHR_UNIFIED_IMAGE_LAYOUTS_EXTENSION_NAME))
+          qvk.unified_image_layouts_supported = 1;
       }
       picked_device = i;
       if(preferred_device_name)
@@ -420,14 +428,14 @@ qvk_init(const char *preferred_device_name, int preferred_device_id, int window,
   };
   VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR layouts = {
     .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFIED_IMAGE_LAYOUTS_FEATURES_KHR,
-    .pNext = &devsize,
+    .pNext = qvk.shader64bit_indexing_supported ? (void*)&devsize : devsize.pNext,
     .unifiedImageLayouts = VK_TRUE,
     .unifiedImageLayoutsVideo = VK_TRUE,
   };
   VkPhysicalDeviceFeatures2 device_features = {
     .sType    = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
     .features = dev_features,
-    .pNext    = &layouts,
+    .pNext    = qvk.unified_image_layouts_supported ? (void*)&layouts : layouts.pNext,
   };
   vkGetPhysicalDeviceFeatures2(qvk.physical_device, &device_features);
   // now find out whether we *really* support 32-bit floating point atomic adds:
@@ -448,23 +456,23 @@ qvk_init(const char *preferred_device_name, int preferred_device_id, int window,
       qvk.float_atomics_supported ? "with" : "without",
       qvk.coopmat_supported       ? "with" : "without");
 
-  const char *requested_device_extensions[30] = {
-    VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,   // intel doesn't have it pre 2015 (hd 520)
-    VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME, // 64 bit ssbo addresses
-    VK_KHR_UNIFIED_IMAGE_LAYOUTS_EXTENSION_NAME, // general image layouts
-    VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME, // intel doesn't have it pre 2015 (hd 520)
-    VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME,
-    // ray tracing
-    VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME,
-    VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME,
-    VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME,
-    VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME,
-    VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME,
-    VK_KHR_RAY_QUERY_EXTENSION_NAME,
-    // VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME, // to bring intel + amd in line with our 32-wide code..
-    // end of ray tracing
-  };
-  int len = (qvk.raytracing_supported ? 11 : 5);
+  const char *requested_device_extensions[30];
+  int len = 0;
+  requested_device_extensions[len++] = VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME;   // intel doesn't have it pre 2015 (hd 520)
+  if(qvk.shader64bit_indexing_supported)
+    requested_device_extensions[len++] = VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME; // 64 bit ssbo addresses
+  if(qvk.unified_image_layouts_supported)
+    requested_device_extensions[len++] = VK_KHR_UNIFIED_IMAGE_LAYOUTS_EXTENSION_NAME; // general image layouts
+  requested_device_extensions[len++] = VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME;
+  if(qvk.raytracing_supported)
+  {
+    requested_device_extensions[len++] = VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME;
+    requested_device_extensions[len++] = VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME;
+    requested_device_extensions[len++] = VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME;
+    requested_device_extensions[len++] = VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME;
+    requested_device_extensions[len++] = VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME;
+    requested_device_extensions[len++] = VK_KHR_RAY_QUERY_EXTENSION_NAME;
+  }
   if(qvk.float_atomics_supported) requested_device_extensions[len++] = VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME;
   if(qvk.coopmat_supported) requested_device_extensions[len++] = VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME;
   if(qvk.subgroup_size_control_supported) requested_device_extensions[len++] = VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME;

--- a/src/qvk/qvk.h
+++ b/src/qvk/qvk.h
@@ -137,6 +137,8 @@ typedef struct qvk_t
   int                         float_atomics_supported;
   int                         coopmat_supported;
   int                         subgroup_size_control_supported;
+  int                         shader64bit_indexing_supported;
+  int                         unified_image_layouts_supported;
   int                         blit_supported;
   int                         hdr_supported;
 }


### PR DESCRIPTION
Latest master was crashing on my machine due to requiring the VK_EXT_shader_64bit_indexing support unconditionally. Made it optional and loaded only if its supported.

Also made the VK_KHR_unified_image_layouts optional, since it isn't supported by a lot of older hardware.