### PR TITLE
qvk: fix memory leak in heap_protected cleanup

### DIFF
--- a/src/pipe/graph-run-nodes-allocate.h
+++ b/src/pipe/graph-run-nodes-allocate.h
@@ -1168,6 +1168,7 @@ dt_graph_run_nodes_allocate(
     // free pipeline resources if previously allocated anything:
     dt_vkalloc_nuke(&graph->heap);
     dt_vkalloc_nuke(&graph->heap_1);
+    dt_vkalloc_nuke(&graph->heap_protected);
     dt_vkalloc_nuke(&graph->heap_staging);
     graph->dset_cnt_image_read = 0;
     graph->dset_cnt_image_write = 0;


### PR DESCRIPTION
Was facing some out of memory errors and noticed the protected heap was not included in the dt_vkalloc_nuke calls. 