### PR TITLE
gui: add color assessment mode

### DIFF
--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -220,6 +220,9 @@ int dt_gui_init()
   if(snprintf(configfile, sizeof(configfile), "%s/config.rc", dt_pipe.homedir) < 512)
     dt_rc_read(&vkdt.rc, configfile);
 
+  vkdt.style.color_assessment_margin = dt_rc_get_float(&vkdt.rc, "gui/color_assessment_margin", 0.10f);
+  vkdt.style.color_assessment_frame_wd = dt_rc_get_float(&vkdt.rc, "gui/color_assessment_frame_wd", 0.03f);
+
   vkdt.wstate.copied_imgid = -1u; // none copied at startup
   threads_mutex_init(&vkdt.wstate.notification_mutex, 0);
 

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -42,6 +42,8 @@ typedef struct dt_gui_style_t
   float panel_width_frac;   // width of the side panel as fraction of the total window width
   float border_frac;        // width of border between image and panel
   float fontsize;           // font height in pixels
+  float color_assessment_margin;   // color assessment margin
+  float color_assessment_frame_wd; // color assessment frame width
   struct nk_color colour[NK_COLOR_COUNT+7];
 }
 dt_gui_style_t;
@@ -109,6 +111,7 @@ typedef struct dt_gui_wstate_t
   int fullscreen_view;          // darkroom mode without panels
   int history_view;             // darkroom mode with left panel shown (history view)
   float dopesheet_view;         // darkroom mode dopesheet, stores adaptive size (0 means collapsed)
+  int color_assessment;         // color assessment mode active
 
   int have_joystick;            // found and enabled a joystick (disable via gui/disable_joystick in config)
   int joystick_id;              // like GLFW_JOYSTICK_1

--- a/src/gui/render_darkroom.c
+++ b/src/gui/render_darkroom.c
@@ -88,7 +88,8 @@ enum hotkey_names_t
   s_hotkey_dragkey_yinc     = 39,
   s_hotkey_dragkey_ydec_alt = 40,
   s_hotkey_dragkey_yinc_alt = 41,
-  s_hotkey_count            = 42,
+  s_hotkey_color_assessment = 42,
+  s_hotkey_count            = 43,
 };
 
 static const int hk_darkroom_size = 128;
@@ -137,6 +138,7 @@ static hk_t hk_darkroom[128] = {
   {"dragkey y-inc",     "step armed parameter up",              {GLFW_KEY_UP}},
   {"dragkey y-dec alt", "step armed parameter down (alt)",      {GLFW_KEY_J}},
   {"dragkey y-inc alt", "step armed parameter up (alt)",        {GLFW_KEY_K}},
+  {"color assessment", "toggle color assessment mode", {GLFW_KEY_LEFT_CONTROL, GLFW_KEY_B}},
 };
 
 // used to communicate between the gui helper functions
@@ -284,6 +286,10 @@ hotkey_dispatch:
       break;
     case s_hotkey_dopesheet:
       dt_gui_dr_toggle_dopesheet();
+      break;
+    case s_hotkey_color_assessment:
+      vkdt.wstate.color_assessment ^= 1;
+      dt_image_reset_zoom(&vkdt.wstate.img_widget);
       break;
     case s_hotkey_rate_0: dt_gui_rate_0(); break;
     case s_hotkey_rate_1: dt_gui_rate_1(); break;
@@ -779,6 +785,30 @@ void render_darkroom()
           dt_gui_edit_hotkeys();
         if(nk_button_label(ctx, "toggle perf overlay"))
           vkdt.wstate.show_perf_overlay ^= 1;
+        dt_tooltip("toggle color assessment mode");
+        if(nk_button_label(ctx, "toggle color assessment"))
+        {
+          vkdt.wstate.color_assessment ^= 1;
+          dt_image_reset_zoom(&vkdt.wstate.img_widget);
+        }
+        dt_tooltip("outer margin size of the color assessment frame as fraction of the window size");
+        nk_layout_row(ctx, NK_DYNAMIC, row_height, 2, ratio);
+        float old_ca_margin = vkdt.style.color_assessment_margin;
+        nk_tab_property(float, ctx, "#", 0.01f, &vkdt.style.color_assessment_margin, 0.5f, 0.01f, 0.01f);
+        nk_label(ctx, "color assessment margin", NK_TEXT_LEFT);
+        if(old_ca_margin != vkdt.style.color_assessment_margin)
+        {
+          dt_image_reset_zoom(&vkdt.wstate.img_widget);
+          dt_rc_set_float(&vkdt.rc, "gui/color_assessment_margin", vkdt.style.color_assessment_margin);
+        }
+
+        dt_tooltip("white frame thickness as fraction of the window size");
+        nk_layout_row(ctx, NK_DYNAMIC, row_height, 2, ratio);
+        float old_ca_frame_wd = vkdt.style.color_assessment_frame_wd;
+        nk_tab_property(float, ctx, "#", 0.001f, &vkdt.style.color_assessment_frame_wd, 0.1f, 0.001f, 0.001f);
+        nk_label(ctx, "color assessment frame width", NK_TEXT_LEFT);
+        if(old_ca_frame_wd != vkdt.style.color_assessment_frame_wd)
+          dt_rc_set_float(&vkdt.rc, "gui/color_assessment_frame_wd", vkdt.style.color_assessment_frame_wd);
         nk_layout_row(ctx, NK_DYNAMIC, row_height, 2, ratio);
 
         dt_tooltip("level of detail: 1 means full res, any higher number will render on reduced resolution.");

--- a/src/gui/widget_image.h
+++ b/src/gui/widget_image.h
@@ -57,7 +57,7 @@ dt_image_events(struct nk_context *ctx, dt_image_widget_t *w, int hovered, int m
         float q[2] = {
           p[2*corner_hovered],
           p[2*corner_hovered+1]};
-        float rad = 0.02 * vkdt.state.center_wd;
+        float rad = 0.02 * w->win_w;
         nk_fill_circle(buf, (struct nk_rect){q[0]-rad, q[1]-rad, 2*rad, 2*rad}, (struct nk_color){0x77,0x77,0x77,0x77});
         if(hovered && nk_input_is_mouse_down(&ctx->input, NK_BUTTON_LEFT))
         {
@@ -139,7 +139,7 @@ dt_image_events(struct nk_context *ctx, dt_image_widget_t *w, int hovered, int m
       }
       if(edge_hovered >= 0)
       {
-        float o = vkdt.state.center_wd * 0.02;
+        float o = w->win_w * 0.02;
         float q0[8] = { p[0], p[1], p[2], p[3], p[2],   p[3]-o, p[0],   p[1]-o};
         float q1[8] = { p[2], p[3], p[4], p[5], p[4]+o, p[5],   p[2]+o, p[3]};
         float q2[8] = { p[4], p[5], p[6], p[7], p[6],   p[7]+o, p[4],   p[5]+o};
@@ -198,8 +198,8 @@ dt_image_events(struct nk_context *ctx, dt_image_widget_t *w, int hovered, int m
       float v[2] = { vkdt.wstate.state[0], 0.5 };
       float p[2];
       dt_image_to_view(&vkdt.wstate.img_widget, v, p);
-      nk_stroke_line(buf, p[0], vkdt.state.center_y, p[0],
-          vkdt.state.center_y + vkdt.state.center_ht, 1.0, nk_white);
+      nk_stroke_line(buf, p[0], w->win_y, p[0],
+          w->win_y + w->win_h, 1.0, nk_white);
       float vv[] = {pos.x, pos.y}, n[2] = {0};
       dt_image_from_view(&vkdt.wstate.img_widget, vv, n);
       if(hovered && nk_input_is_mouse_pressed(&ctx->input, NK_BUTTON_LEFT))
@@ -221,9 +221,9 @@ dt_image_events(struct nk_context *ctx, dt_image_widget_t *w, int hovered, int m
 
       const int modid = vkdt.wstate.active_widget_modid;
       const float scale = vkdt.wstate.img_widget.scale *
-        MIN(vkdt.state.center_wd / (float)
+        MIN(w->win_w / (float)
             vkdt.graph_dev.module[modid].connector[0].roi.wd,
-            vkdt.state.center_ht / (float)
+            w->win_h / (float)
             vkdt.graph_dev.module[modid].connector[0].roi.ht);
       for(int i=0;i<2;i++)
       { // ui scaled roi wd * radius * stroke radius
@@ -347,8 +347,7 @@ dt_image_events(struct nk_context *ctx, dt_image_widget_t *w, int hovered, int m
     w->look_at_x = w->old_look_x-img1[0]+img0[0];
     w->look_at_y = w->old_look_y-img1[1]+img0[1];
   }
-  w->look_at_x = CLAMP(w->look_at_x, -5.f, 5.f);
-  w->look_at_y = CLAMP(w->look_at_y, -5.f, 5.f);
+  dt_image_clamp_zoom(w, vkdt.wstate.color_assessment);
 }
 
 static inline void
@@ -364,8 +363,16 @@ dt_image(
   w->wd = (float)out->connector[0].roi.wd;
   w->ht = (float)out->connector[0].roi.ht;
   struct nk_rect wb = nk_widget_bounds(ctx);
-  w->win_x = wb.x; w->win_y = wb.y;
-  w->win_w = wb.w; w->win_h = wb.h;
+  dt_image_clamp_zoom(w, vkdt.wstate.color_assessment);
+  if (vkdt.wstate.color_assessment)
+  {
+    dt_image_layout_color_assessment(w, wb.x, wb.y, wb.w, wb.h, vkdt.style.color_assessment_margin, vkdt.style.color_assessment_frame_wd);
+  }
+  else
+  {
+    w->win_x = wb.x; w->win_y = wb.y;
+    w->win_w = wb.w; w->win_h = wb.h;
+  }
   float im0[2], im1[2];
   float v0[2] = {w->win_x, w->win_y};
   float v1[2] = {w->win_x+w->win_w, w->win_y+w->win_h};
@@ -391,6 +398,22 @@ dt_image(
     disp.w = (int)(ns * subimg.w); disp.h = (int)(ns * subimg.h);
   }
   struct nk_command_buffer *buf = nk_window_get_canvas(ctx);
+  if (vkdt.wstate.color_assessment)
+  {
+    struct nk_color gray_bg = { 119, 119, 119, 255 }; // middle gray
+    nk_fill_rect(buf, wb, 0.0f, gray_bg);
+
+    float frame_wd_px = vkdt.style.color_assessment_frame_wd * MIN(wb.w, wb.h);
+    if (frame_wd_px < 1.0f) frame_wd_px = 1.0f;
+
+    struct nk_rect white_rect = {
+      w->win_x - frame_wd_px,
+      w->win_y - frame_wd_px,
+      w->win_w + 2.0f * frame_wd_px,
+      w->win_h + 2.0f * frame_wd_px
+    };
+    nk_fill_rect(buf, white_rect, 0.0f, (struct nk_color){255, 255, 255, 255});
+  }
   struct nk_image nkimg = nk_subimage_ptr(out->dset[display_frame], w->wd, w->ht, subimg);
   int hover = nk_input_is_mouse_hovering_rect(&ctx->input, disp);
   nk_draw_image(buf, disp, &nkimg, (struct nk_color){0xff,0xff,0xff,0xff});

--- a/src/gui/widget_image_util.h
+++ b/src/gui/widget_image_util.h
@@ -100,9 +100,51 @@ dt_image_zoom_at(
   float max_scale = 8.0f * (1.0f/scale_fit);
 
   w->scale = CLAMP(w->scale * factor, min_scale, max_scale);
-
+  
   float img1[2];
   dt_image_from_view(w, view, img1);
   w->look_at_x += -img1[0] + img[0];
   w->look_at_y += -img1[1] + img[1];
+}
+
+static inline void
+dt_image_clamp_zoom(
+    dt_image_widget_t *w,
+    int                color_assessment)
+{
+  if (color_assessment)
+  {
+    if (w->scale < 1.0f) w->scale = 1.0f;
+    float range_x = 0.5f - 0.5f / w->scale;
+    float range_y = 0.5f - 0.5f / w->scale;
+    w->look_at_x = CLAMP(w->look_at_x, -range_x, range_x);
+    w->look_at_y = CLAMP(w->look_at_y, -range_y, range_y);
+  }
+  else
+  {
+    w->look_at_x = CLAMP(w->look_at_x, -5.f, 5.f);
+    w->look_at_y = CLAMP(w->look_at_y, -5.f, 5.f);
+  }
+}
+
+static inline void
+dt_image_layout_color_assessment(
+    dt_image_widget_t *w,
+    float              win_x,
+    float              win_y,
+    float              win_w,
+    float              win_h,
+    float              margin,
+    float              frame_wd_frac)
+{
+  float m = 1.0f - 2.0f * margin;
+  float frame_wd_px = frame_wd_frac * MIN(win_w, win_h);
+  if (frame_wd_px < 1.0f) frame_wd_px = 1.0f;
+
+  float ar = w->wd / w->ht;
+  w->win_h = MIN((win_w * m - 2.0f * frame_wd_px) / ar, win_h * m - 2.0f * frame_wd_px);
+  w->win_w = ar * w->win_h;
+
+  w->win_x = win_x + (win_w - w->win_w) * 0.5f;
+  w->win_y = win_y + (win_h - w->win_h) * 0.5f;
 }


### PR DESCRIPTION
This pull request adds a darktable-like color assessment mode with customizable margin and border sizes.

<img width="2880" height="1734" alt="image" src="https://github.com/user-attachments/assets/b7fa072f-e58c-4a76-8d8a-ef64beed8290" />
