### PR TITLE
widget_image: proportional zoom with configurable gui/zoom_speed

### DIFF
--- a/src/gui/widget_image.h
+++ b/src/gui/widget_image.h
@@ -321,8 +321,7 @@ dt_image_events(struct nk_context *ctx, dt_image_widget_t *w, int hovered, int m
     if(yoff != 0)
     { // mouse wheel (yoff is the input)
       ctx->input.mouse.scroll_delta.y = 0;
-      const float factor = yoff > 0.0f ? 1.1f : 0.9f;
-      dt_image_zoom_at(w, mpos.x, mpos.y, factor);
+      dt_image_zoom_at(w, mpos.x, mpos.y, powf(dt_rc_get_float(&vkdt.rc, "gui/zoom_speed", 1.1f), yoff));
     }
   }
   else


### PR DESCRIPTION
Makes scrolling in the darkroom smoother when using a touchpad (fractional scrolling) and adds a setting to modify speed. It now feels much snappier on my laptop.