### PR TITLE
colour, clut: add fixed-grid multi-anchor profiles and auto-temperature

### DIFF
--- a/src/pipe/modules/colour/atemp-.comp
+++ b/src/pipe/modules/colour/atemp-.comp
@@ -1,0 +1,5 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+#define HAVE_NO_ATOMICS
+
+#include "atemp-impl.glsl"

--- a/src/pipe/modules/colour/atemp-impl.glsl
+++ b/src/pipe/modules/colour/atemp-impl.glsl
@@ -1,0 +1,85 @@
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(std140, set = 0, binding = 1) uniform params_t
+{
+  vec4  mul;
+  mat3  cam_to_rec2020;
+  uvec4 N;
+  mat3  rbf_P;
+  vec4  rbf_c[24];
+  vec4  rbf_p[24];
+  float temp;
+  uint  colour_mode;
+  float saturation;
+  uint  pick_mode;
+  uint  gamut_mode;
+  uint  primaries;
+  uint  trc;
+  float clip_highlights;
+  vec4  auto_wb;
+} params;
+
+layout(push_constant, std140) uniform push_t { int have_pick; } push;
+
+layout(set = 1, binding = 0) uniform sampler2D img_clut;
+layout(set = 1, binding = 1) uniform writeonly image2D img_temp;
+layout(set = 1, binding = 2
+#ifdef HAVE_NO_ATOMICS
+) uniform usampler2D img_pick;
+#else
+) uniform sampler2D img_pick;
+#endif
+
+#include "clut.glsl"
+
+void tri2quad(inout vec2 tc)
+{
+  tc.y = tc.y / (1.0-tc.x);
+  tc.x = (1.0-tc.x)*(1.0-tc.x);
+}
+
+vec3 picked_rgb()
+{
+#ifdef HAVE_NO_ATOMICS
+  return vec3(
+      uintBitsToFloat(texelFetch(img_pick, ivec2(0, 0), 0).r),
+      uintBitsToFloat(texelFetch(img_pick, ivec2(0, 1), 0).r),
+      uintBitsToFloat(texelFetch(img_pick, ivec2(0, 2), 0).r));
+#else
+  return vec3(
+      texelFetch(img_pick, ivec2(0, 0), 0).r,
+      texelFetch(img_pick, ivec2(0, 1), 0).r,
+      texelFetch(img_pick, ivec2(0, 2), 0).r);
+#endif
+}
+
+void main()
+{
+  if(params.temp >= 0.0) { imageStore(img_temp, ivec2(0), vec4(-1.0)); return; }
+
+  ivec2 clut_size = textureSize(img_clut, 0);
+  int nbands = clut_size.x / clut_size.y;
+  int n = clut_nanchor(nbands);
+
+  vec3 neutral = vec3(1.0/max(params.auto_wb.r, 1e-6), 1.0, 1.0/max(params.auto_wb.b, 1e-6));
+  if(push.have_pick != 0 && (params.pick_mode & 4) != 0) neutral = picked_rgb();
+  float nb = max(neutral.r+neutral.g+neutral.b, 1e-6);
+  vec2 ntc = neutral.rb/nb;
+  tri2quad(ntc);
+
+  const vec2 target = vec2(1.0/3.0);
+  vec2 rb_prev = clut_chroma(ntc, 0, nbands);
+  float best_bp = 0.0, best_res = 1e30;
+  for(int k=0;k<n-1;k++)
+  {
+    vec2 rb_next = clut_chroma(ntc, k+1, nbands);
+    vec2 dv = rb_next - rb_prev;
+    float denom = dot(dv, dv);
+    float m = denom > 1e-12 ? dot(target-rb_prev, dv)/denom : 0.0;
+    float mc = clamp(m, 0.0, 1.0);
+    float res = length(target-(rb_prev+mc*dv));
+    if(res < best_res) { best_res = res; best_bp = float(k)+mc; }
+    rb_prev = rb_next;
+  }
+  imageStore(img_temp, ivec2(0), vec4(best_bp/float(max(n-1, 1))));
+}

--- a/src/pipe/modules/colour/autotemp.comp
+++ b/src/pipe/modules/colour/autotemp.comp
@@ -1,0 +1,4 @@
+#version 460
+#extension GL_GOOGLE_include_directive : enable
+
+#include "atemp-impl.glsl"

--- a/src/pipe/modules/colour/clut.glsl
+++ b/src/pipe/modules/colour/clut.glsl
@@ -1,0 +1,20 @@
+// img_clut is declared by the including shader; n==2 uses the legacy layout.
+
+int clut_nanchor(int nbands)
+{
+  return (nbands * 2) / 3;
+}
+
+vec2 clut_chroma(vec2 tc, int idx, int nbands)
+{
+  int band = (nbands == 3) ? 2*idx : idx;
+  return texture(img_clut, vec2((tc.x + float(band)) / float(nbands), tc.y)).xy;
+}
+
+float clut_luminance(vec2 tc, int idx, int n, int nbands)
+{
+  if(nbands == 3)
+    return texture(img_clut, vec2((tc.x + 1.0) / 3.0, tc.y))[idx];
+  vec2 pair = texture(img_clut, vec2((tc.x + float(n + idx/2)) / float(nbands), tc.y)).xy;
+  return (idx % 2 == 0) ? pair.x : pair.y;
+}

--- a/src/pipe/modules/colour/flat.mk
+++ b/src/pipe/modules/colour/flat.mk
@@ -1,3 +1,5 @@
 MOD_LDFLAGS=-lm
 pipe/modules/colour/main.comp.spv: pipe/modules/colour/main-impl.glsl
 pipe/modules/colour/main-.comp.spv: pipe/modules/colour/main-impl.glsl
+pipe/modules/colour/autotemp.comp.spv: pipe/modules/colour/atemp-impl.glsl pipe/modules/colour/clut.glsl
+pipe/modules/colour/atemp-.comp.spv: pipe/modules/colour/atemp-impl.glsl pipe/modules/colour/clut.glsl

--- a/src/pipe/modules/colour/main-impl.glsl
+++ b/src/pipe/modules/colour/main-impl.glsl
@@ -13,7 +13,7 @@ layout(std140, set = 0, binding = 1) uniform params_t
   mat3  rbf_P;             // rbf matrix part
   vec4  rbf_c[24];         // rbf coefficients
   vec4  rbf_p[24];         // rbf positions
-  float temp;              // colour temperature for wb 0:2856 1:6504
+  float temp;              // CLUT anchor blend from Kelvin UI: 0 = high CCT, 1 = low CCT
   uint  colour_mode;       // 0-matrix 1-clut
   float saturation;        // multiplier on chroma
   uint  pick_mode;         // what do we do with the colour picked input?
@@ -21,6 +21,7 @@ layout(std140, set = 0, binding = 1) uniform params_t
   uint  primaries;         // see module.h
   uint  trc;
   float clip_highlights;   // pass highlights through or clip at minimum of rgb after processing
+  vec4  auto_wb;           // input image's as-shot camera wb, g-normalised
 } params;
 
 layout(push_constant, std140) uniform push_t
@@ -41,6 +42,9 @@ layout(set = 1, binding = 3
 #endif
 layout(set = 1, binding = 4) uniform sampler2D img_abney;
 layout(set = 1, binding = 5) uniform sampler2D img_spectra;
+layout(set = 1, binding = 6) uniform sampler2D img_auto_temp;
+
+#include "clut.glsl"
 
 vec3 // return adapted rec2020
 cat16(vec3 rec2020_d65, vec3 rec2020_src, vec3 rec2020_dst)
@@ -80,11 +84,20 @@ vec3 process_clut(vec3 rgb)
   float b = rgb.r+rgb.g+rgb.b;
   vec2 tc = rgb.rb/b;
   tri2quad(tc);
-  tc.x /= 3.0;
-  vec4 rbrb = vec4(texture(img_clut, tc).xy, texture(img_clut, tc+vec2(2.0/3.0, 0.0)).xy);
-  vec2 L2 = texture(img_clut, tc + vec2(1.0/3.0, 0.0)).xy;
-  float L = mix(L2.x, L2.y, params.temp);
-  vec2 rb = mix(rbrb.xy, rbrb.zw, params.temp);
+
+  ivec2 clut_size = textureSize(img_clut, 0);
+  int nbands = clut_size.x / clut_size.y;
+  int n = clut_nanchor(nbands);
+
+  float temp = params.temp < 0.0 ? texelFetch(img_auto_temp, ivec2(0), 0).r : params.temp;
+  float bp = clamp(temp, 0.0, 1.0) * float(n-1);
+  int k0 = int(bp);
+  int k1 = min(k0+1, n-1);
+  float frac = bp - float(k0);
+
+  vec2 rb = mix(clut_chroma(tc, k0, nbands), clut_chroma(tc, k1, nbands), frac);
+  float L  = mix(clut_luminance(tc, k0, n, nbands), clut_luminance(tc, k1, n, nbands), frac);
+
   rgb = vec3(rb.x, 1.0-rb.x-rb.y, rb.y);
   return rgb * L * b;
 }

--- a/src/pipe/modules/colour/main.c
+++ b/src/pipe/modules/colour/main.c
@@ -3,6 +3,32 @@
 #include <math.h>
 #include <stdlib.h>
 
+static inline float
+legacy_temp_position(const float temp)
+{
+  return 1.0f - CLAMP(tanf(asinhf(46.3407f+temp))+(-0.0287128f*cosf(0.000798585f*(714.855f-temp)))+0.942275f, 0.0f, 1.0f);
+}
+
+static float
+auto_temp_kelvin(const float position, const uint32_t nbands)
+{
+  if(nbands > 3)
+  {
+    const float m_lo = 1e6f/15000.0f, m_hi = 1e6f/2000.0f;
+    return 1e6f/(m_lo + CLAMP(position, 0.0f, 1.0f)*(m_hi-m_lo));
+  }
+
+  // Invert the legacy two-anchor mapping.
+  float lo = 2000.0f, hi = 15000.0f;
+  for(int k=0;k<24;k++)
+  {
+    const float mid = 0.5f*(lo+hi);
+    if(legacy_temp_position(mid) < position) hi = mid;
+    else                                     lo = mid;
+  }
+  return 0.5f*(lo+hi);
+}
+
 void ui_callback(
     dt_module_t *mod,
     dt_token_t   param)
@@ -236,10 +262,26 @@ void commit_params(dt_graph_t *graph, dt_module_t *module)
   f[2] = p_wb[2] / p_wb[1];
   f[3] = powf(2.0f, ((float*)module->param)[0]);
   int off = 4+12+4+12+4*24+4*24;
-  // linear, as the dng spec says:
-  // f[off+0] = 1.0f - CLAMP((p_tmp - 2856.f)/(6504.f-2856.f), 0.0f, 1.0f);
-  // turingbot reverses this function to more accurately blend along CCT:
-  f[off+0] = 1.0f - CLAMP(tanf(asinhf(46.3407f+p_tmp))+(-0.0287128f*cosf(0.000798585f*(714.855f-p_tmp)))+0.942275f, 0.0f, 1.0f);
+  // Three bands identify the legacy layout.
+  const uint32_t clut_ht = module->connector[2].roi.full_ht;
+  const uint32_t nbands  = clut_ht ? module->connector[2].roi.full_wd / clut_ht : 3;
+  if(p_tmp <= 0.0f)
+  { // Resolve as-shot WB once.
+    f[off+0] = -1.0f;
+    if(dt_connected(module->connector+2))
+      module->flags |= s_module_request_write_sink;
+  }
+  else if(nbands > 3)
+  { // Mired-uniform 2000--15000K anchors.
+    const float T_lo = 2000.0f, T_hi = 15000.0f;
+    const float m_lo = 1e6f/T_hi, m_hi = 1e6f/T_lo;
+    const float m = 1e6f/CLAMP(p_tmp, T_lo, T_hi);
+    f[off+0] = CLAMP((m - m_lo)/(m_hi - m_lo), 0.0f, 1.0f);
+  }
+  else
+  { // Legacy two-anchor mapping.
+    f[off+0] = 1.0f - CLAMP(tanf(asinhf(46.3407f+p_tmp))+(-0.0287128f*cosf(0.000798585f*(714.855f-p_tmp)))+0.942275f, 0.0f, 1.0f);
+  }
   i[off+1] = p_mat == 4 ? 1 : 0; // colour mode matrix or clut
   f[off+2] = p_sat;
   i[off+3] = p_pck;
@@ -247,6 +289,16 @@ void commit_params(dt_graph_t *graph, dt_module_t *module)
   i[off+5] = img_param->colour_primaries;
   i[off+6] = img_param->colour_trc;
   f[off+7] = p_clp ? p_clm : 0.0;
+  float auto_wb[3] = {
+    img_param->whitebalance[0],
+    img_param->whitebalance[1],
+    img_param->whitebalance[2]};
+  if(!(auto_wb[0] > 0.0f) || !(auto_wb[1] > 0.0f) || !(auto_wb[2] > 0.0f))
+    auto_wb[0] = auto_wb[1] = auto_wb[2] = 1.0f;
+  f[off+8]  = auto_wb[0]/auto_wb[1];
+  f[off+9]  = 1.0f;
+  f[off+10] = auto_wb[2]/auto_wb[1];
+  f[off+11] = 1.0f;
 
   if(p_mat == 1)
   { // the one that comes with the image from the source node:
@@ -314,8 +366,50 @@ void commit_params(dt_graph_t *graph, dt_module_t *module)
 
 int init(dt_module_t *mod)
 {
-  mod->committed_param_size = sizeof(float)*(4+12+4+12+4*24+4*24+5+8+1);
+  mod->committed_param_size = sizeof(float)*(4+12+4+12+4*24+4*24+5+8+5);
   return 0;
+}
+
+void
+animate(
+    dt_graph_t  *graph,
+    dt_module_t *module)
+{
+  const int tempid = dt_module_get_param(module->so, dt_token("temp"));
+  if(dt_module_param_float(module, tempid)[0] <= 0.0f && dt_connected(module->connector+2))
+    module->flags |= s_module_request_write_sink;
+}
+
+dt_graph_run_t
+check_params(
+    dt_module_t *module,
+    uint32_t     parid,
+    uint32_t     num,
+    void        *oldval)
+{
+  if(parid >= 0 && parid < module->so->num_params &&
+      module->so->param[parid]->name == dt_token("temp") &&
+      dt_module_param_float(module, parid)[0] <= 0.0f)
+    module->flags |= s_module_request_write_sink;
+  return s_graph_run_record_cmd_buf;
+}
+
+void
+write_sink(
+    dt_module_t            *module,
+    void                   *buf,
+    dt_write_sink_params_t *p)
+{
+  const float position = ((const float *)buf)[0];
+  const int tempid = dt_module_get_param(module->so, dt_token("temp"));
+  float *temp = (float *)dt_module_param_float(module, tempid);
+  if(!temp || temp[0] > 0.0f || !(position >= 0.0f && position <= 1.0f)) return;
+
+  const uint32_t clut_ht = module->connector[2].roi.full_ht;
+  const uint32_t nbands  = clut_ht ? module->connector[2].roi.full_wd / clut_ht : 3;
+  temp[0] = auto_temp_kelvin(position, nbands);
+  module->flags &= ~s_module_request_write_sink;
+  module->graph->runflags |= s_graph_run_record_cmd_buf;
 }
 
 void create_nodes(
@@ -326,19 +420,37 @@ void create_nodes(
   int have_pick = dt_connected(module->connector+3);
   int have_abney = dt_connected(module->connector+4) && dt_connected(module->connector+5);
   const int pc[] = { have_clut, have_pick, have_abney };
+  const int pc_auto[] = { have_pick };
+  int id_auto = -1;
+  if(have_clut)
+  { // The sink turns temp:0 into editable Kelvin.
+    const dt_roi_t tiny = { .wd = 1, .ht = 1 };
+    const char *kernel = (qvk.float_atomics_supported || !have_pick || module->connector[3].format != dt_token("atom")) ? "autotemp" : "atemp-";
+    id_auto = dt_node_add(graph, module, "colour", kernel, 1, 1, 1, sizeof(pc_auto), pc_auto, 3,
+        "clut", "read",  "rg", "f16", dt_no_roi,
+        "temp", "write", "y",  "f32", &tiny,
+        "picked", "read", "r",  have_pick ? dt_token_str(module->connector[3].format) : "f16", dt_no_roi);
+    const int id_sink = dt_node_add(graph, module, "colour", "sink", 1, 1, 1, 0, 0, 1,
+        "temp", "sink", "y", "f32", dt_no_roi);
+    dt_connector_copy(graph, module, 2, id_auto, 0);
+    if(have_pick) dt_connector_copy(graph, module, 3, id_auto, 2);
+    else          dt_connector_copy(graph, module, 0, id_auto, 2);
+    CONN(dt_node_connect(graph, id_auto, 1, id_sink, 0));
+  }
   // we'll need the uint sampler in case there are no float atomics supported.
   // but only if anything picked is connected at all. our dummy is f16 in any
   // case and will run through the normal code with float atomics (there are no
   // atomics here, we just read the buffer and need to know if it's uint or float)
   const int nodeid = dt_node_add(graph, module, "colour",
       (qvk.float_atomics_supported || !have_pick || (have_pick && module->connector[3].format != dt_token("atom"))) ? "main" : "main-",
-      module->connector[0].roi.wd, module->connector[0].roi.ht, 1, sizeof(pc), pc, 6,
+      module->connector[0].roi.wd, module->connector[0].roi.ht, 1, sizeof(pc), pc, 7,
       "input",   "read",  "rgba", "f16",  dt_no_roi,
       "output",  "write", "rgba", "f16",  &module->connector[0].roi,
       "clut",    "read",  "rgba", "f16",  dt_no_roi,
       "picked",  "read",  "r",    have_pick ? dt_token_str(module->connector[3].format) : "f16", dt_no_roi,
       "abney",   "read",  "rg",   "f16",  dt_no_roi,
-      "spectra", "read",  "rgba", "f16",  dt_no_roi);
+      "spectra", "read",  "rgba", "f16",  dt_no_roi,
+      "autotemp",  "read", "y",   "f32",  dt_no_roi);
   dt_connector_copy(graph, module, 0, nodeid, 0);
   dt_connector_copy(graph, module, 1, nodeid, 1);
   if(have_clut)  dt_connector_copy(graph, module, 2, nodeid, 2);
@@ -349,4 +461,6 @@ void create_nodes(
   else           dt_connector_copy(graph, module, 0, nodeid, 4); // dummy
   if(have_abney) dt_connector_copy(graph, module, 5, nodeid, 5);
   else           dt_connector_copy(graph, module, 0, nodeid, 5); // dummy
+  if(id_auto >= 0) CONN(dt_node_connect(graph, id_auto, 1, nodeid, 6));
+  else             dt_connector_copy(graph, module, 0, nodeid, 6); // dummy
 }

--- a/src/pipe/modules/colour/params.ui
+++ b/src/pipe/modules/colour/params.ui
@@ -1,11 +1,11 @@
 exposure:slider:-5:5
 sat:slider:0.0:3.0
-picked:combo:ignore:white balance:deflicker:both
+picked:combo:ignore:white balance:deflicker:both:temp
 matrix:combo:rec2020:image:XYZ:rec709:clut
 gamut:combo:no limit:limit to spectral locus:limit to rec2020:limit to rec709
 white:rgb:0:2
 group:matrix:4
-temp:slider:2856:6504
+temp:slider:0:15000
 group:-1:0
 clip:combo:preserve highlights:clip highlights
 group:clip:1

--- a/src/pipe/modules/colour/readme.md
+++ b/src/pipe/modules/colour/readme.md
@@ -83,8 +83,8 @@ gamut.
 * `picked` what to do with the picked input colour, if it is connected to the `picked` connector.
   it can be used as source for white balancing and/or deflickering.
 * `matrix` input device transform mode: use the image matrix or a selection of presets, or the colour lut.
-* `temp` if a clut is used, this allows to blend between the two illuminants. usually this
-  is illuminant A and D65 and reflected in the values of the temperature here.
+* `temp` selects the illuminant anchor blend. setting it to `0` resolves once from RAW
+  metadata, or from a connected picker when `picked` is set to `temp`.
 * `white` the white balance destination colour. 1 1 1 is D65. setting this to 0 0 0 (doubleclick to default) will try to load the camera white balance.
 * `mat` a hidden parameter containing the coefficients of the image matrix.
 * `cnt` the number of patches to use in the rbf mapping

--- a/src/tools/clut/src/mkclut.c
+++ b/src/tools/clut/src/mkclut.c
@@ -7,6 +7,121 @@
 #include "core/fs.h"
 #include "core/half.h"
 #include "core/inpaint.h"
+#include <math.h>
+
+#define MKCLUT_MAX_ANCHORS 16
+
+// Planckian spectrum, 360--830nm at 1nm.
+static inline int
+synth_illuminant_planckian(
+    double         T,
+    double       (*out)[4])
+{
+  const double h = 6.62606957e-34; // planck's constant [J s]
+  const double c = 299792458.0;    // speed of light [m/s]
+  const double k = 1.3807e-23;     // boltzmann's constant [J/K]
+  int cnt = 0;
+  for(double l = 360.0; l <= 830.0; l += 1.0, cnt++)
+  {
+    const double lambda_m = l * 1e-9;
+    const double lambda5 = lambda_m*lambda_m*lambda_m*lambda_m*lambda_m;
+    const double c1 = 2.0 * h * c * c / lambda5;
+    const double c2 = h * c / (lambda_m * T * k);
+    out[cnt][0] = l;
+    out[cnt][1] = c1 / (exp(c2) - 1.0);
+    out[cnt][2] = out[cnt][3] = 0.0;
+  }
+  return cnt;
+}
+
+// CIE daylight basis functions, 300--830nm at 5nm.
+static const double cie_day_wl[107] = {
+  300,305,310,315,320,325,330,335,340,345,350,355,360,
+  365,370,375,380,385,390,395,400,405,410,415,420,425,
+  430,435,440,445,450,455,460,465,470,475,480,485,490,
+  495,500,505,510,515,520,525,530,535,540,545,550,555,
+  560,565,570,575,580,585,590,595,600,605,610,615,620,
+  625,630,635,640,645,650,655,660,665,670,675,680,685,
+  690,695,700,705,710,715,720,725,730,735,740,745,750,
+  755,760,765,770,775,780,785,790,795,800,805,810,815,
+  820,825,830
+};
+static const double cie_day_s0[107] = {
+  0.04,3.02,6,17.8,29.6,42.45,55.3,56.3,57.3,59.55,61.8,61.65,61.5,
+  65.15,68.8,66.1,63.4,64.6,65.8,80.3,94.8,99.8,104.8,105.35,105.9,101.35,
+  96.8,105.35,113.9,119.75,125.6,125.55,125.5,123.4,121.3,121.3,121.3,117.4,113.5,
+  113.3,113.1,111.95,110.8,108.65,106.5,107.65,108.8,107.05,105.3,104.85,104.4,102.2,
+  100,98,96,95.55,95.1,92.1,89.1,89.8,90.5,90.4,90.3,89.35,88.4,
+  86.2,84,84.55,85.1,83.5,81.9,82.25,82.6,83.75,84.9,83.1,81.3,76.6,
+  71.9,73.1,74.3,75.35,76.4,69.85,63.3,67.5,71.7,74.35,77,71.1,65.2,
+  56.45,47.7,58.15,68.6,66.8,65,65.5,66,63.5,61,57.15,53.3,56.1,
+  58.9,60.4,61.9
+};
+static const double cie_day_s1[107] = {
+  0.02,2.26,4.5,13.45,22.4,32.2,42,41.3,40.6,41.1,41.6,39.8,38,
+  40.2,42.4,40.45,38.5,36.75,35,39.2,43.4,44.85,46.3,45.1,43.9,40.5,
+  37.1,36.9,36.7,36.3,35.9,34.25,32.6,30.25,27.9,26.1,24.3,22.2,20.1,
+  18.15,16.2,14.7,13.2,10.9,8.6,7.35,6.1,5.15,4.2,3.05,1.9,0.95,
+  0,-0.8,-1.6,-2.55,-3.5,-3.5,-3.5,-4.65,-5.8,-6.5,-7.2,-7.9,-8.6,
+  -9.05,-9.5,-10.2,-10.9,-10.8,-10.7,-11.35,-12,-13,-14,-13.8,-13.6,-12.8,
+  -12,-12.65,-13.3,-13.1,-12.9,-11.75,-10.6,-11.1,-11.6,-11.9,-12.2,-11.2,-10.2,
+  -9,-7.8,-9.5,-11.2,-10.8,-10.4,-10.5,-10.6,-10.15,-9.7,-9,-8.3,-8.8,
+  -9.3,-9.55,-9.8
+};
+static const double cie_day_s2[107] = {
+  0,1,2,3,4,6.25,8.5,8.15,7.8,7.25,6.7,6,5.3,
+  5.7,6.1,4.55,3,2.1,1.2,0.05,-1.1,-0.8,-0.5,-0.6,-0.7,-0.95,
+  -1.2,-1.9,-2.6,-2.75,-2.9,-2.85,-2.8,-2.7,-2.6,-2.6,-2.6,-2.2,-1.8,
+  -1.65,-1.5,-1.4,-1.3,-1.25,-1.2,-1.1,-1,-0.75,-0.5,-0.4,-0.3,-0.15,
+  0,0.1,0.2,0.35,0.5,1.3,2.1,2.65,3.2,3.65,4.1,4.4,4.7,
+  4.9,5.1,5.9,6.7,7,7.3,7.95,8.6,9.2,9.8,10,10.2,9.25,
+  8.3,8.95,9.6,9.05,8.5,7.75,7,7.3,7.6,7.8,8,7.35,6.7,
+  5.95,5.2,6.3,7.4,7.1,6.8,6.9,7,6.7,6.4,5.95,5.5,5.8,
+  6.1,6.3,6.5
+};
+
+static inline double cie_day_interp(const double *tab, double l)
+{
+  if(l <= cie_day_wl[0])   return tab[0];
+  if(l >= cie_day_wl[106]) return tab[106];
+  int i = (int)((l - cie_day_wl[0]) / 5.0);
+  double t = (l - cie_day_wl[i]) / 5.0;
+  return tab[i]*(1.0-t) + tab[i+1]*t;
+}
+
+// CIE daylight spectrum, 360--830nm at 1nm.
+static inline int
+synth_illuminant_daylight(
+    double         T,
+    double       (*out)[4])
+{
+  double x = (T <= 7000.0)
+    ? 0.244063 + 0.09911e3/T + 2.9678e6/(T*T) - 4.6070e9/(T*T*T)
+    : 0.237040 + 0.24748e3/T + 1.9018e6/(T*T) - 2.0064e9/(T*T*T);
+  double y = -3.000*x*x + 2.870*x - 0.275;
+  double m = 0.0241 + 0.2562*x - 0.7341*y;
+  double m1 = (-1.3515 - 1.7703*x + 5.9114*y) / m;
+  double m2 = (0.0300 - 31.4424*x + 30.0717*y) / m;
+  int cnt = 0;
+  for(double l = 360.0; l <= 830.0; l += 1.0, cnt++)
+  {
+    out[cnt][0] = l;
+    out[cnt][1] = cie_day_interp(cie_day_s0, l)
+                + m1*cie_day_interp(cie_day_s1, l)
+                + m2*cie_day_interp(cie_day_s2, l);
+    out[cnt][2] = out[cnt][3] = 0.0;
+  }
+  return cnt;
+}
+
+// Planckian below 4000K, daylight otherwise.
+static inline int
+synth_illuminant(
+    double         T,
+    double       (*out)[4])
+{
+  return T < 4000.0 ? synth_illuminant_planckian(T, out) : synth_illuminant_daylight(T, out);
+}
 
 #if 0
 // XXX DEBUG write just the matrix from xyz to rec2020 for precision checks:
@@ -47,7 +162,7 @@ create_chroma_lut_DEBUG(
 }
 #endif
 
-// create 2.5D chroma lut
+// Scatter spectral samples into camera-chroma bins.
 static inline float*
 create_chroma_lut(
     int                   *wd_out,
@@ -57,23 +172,21 @@ create_chroma_lut(
     const double         (*cfa_spec)[4],     // tabulated cfa spectra
     const int              cfa_spec_cnt,
     const double         (*cie_spec)[4],     // tabulated cie observer
-    const int              cie_spec_cnt)
+    const int              cie_spec_cnt,
+    const int              ss)              // source oversampling factor
 {
-  // to avoid interpolation artifacts we only want to place straight pixel
-  // center values of our spectra.lut in the output:
-  int swd = sh->wd, sht = sh->ht; // sampling dimensions
-  int wd  = swd, ht = sht; // output dimensions
+  int wd = sh->wd, ht = sh->ht; // output dimensions
   float *buf = calloc(sizeof(float)*3, wd*ht+1);
+  double *bestd = malloc(sizeof(double)*wd*(uint64_t)ht);
+  for(uint64_t k=0;k<wd*(uint64_t)ht;k++) bestd[k] = 1e300;
 
-  // do two passes over the data
-  // get illum E white point (lowest saturation) in camera rgb and quad param:
+  // Illuminant-E reference luminance.
   const double wcf[] = {0.0, 0.0, 100000.0}; // illuminant E
   double white_cam_rgb[3] = {
     spectrum_integrate(cfa_spec, 0, cfa_spec_cnt, wcf, 3),
     spectrum_integrate(cfa_spec, 1, cfa_spec_cnt, wcf, 3),
     spectrum_integrate(cfa_spec, 2, cfa_spec_cnt, wcf, 3)};
   const double white_cam_rgb_L1 = normalise1(white_cam_rgb);
-  tri2quad(white_cam_rgb, white_cam_rgb+2);
   double xyz_spec[3] = {0.0};
   for(int k=0;k<3;k++)
     xyz_spec[k] = spectrum_integrate(cie_spec, k, cie_spec_cnt, wcf, 3);
@@ -82,122 +195,105 @@ create_chroma_lut(
   const double white_rec2020_L1 = normalise1(rec2020);
   const double ref_L = white_cam_rgb_L1 / white_rec2020_L1;
 
-  // first pass: get rough idea about max deviation from white and the saturation we got there
-  double *angular_ds = calloc(sizeof(double), 360*2);
-  int sample_wd = swd, sample_ht = sht;
+  // Oversample the source grid.
+  const int sample_wd = wd*ss, sample_ht = ht*ss;
+
   for(int j=0;j<sample_ht;j++) for(int i=0;i<sample_wd;i++)
   {
     double xy[2] = {(i+0.5)/sample_wd, (j+0.5)/sample_ht};
     quad2tri(xy+0, xy+1);
-    double cf[3]; // look up the coeffs for the sampled colour spectrum
-    fetch_coeffi(xy, spectra, sh->wd, sh->ht, cf); // nearest
-    if(cf[0] == 0) continue; // discard out of spectral locus
-    double cam_rgb_spec[3] = {0.0}; // camera rgb by processing spectrum * cfa spectrum
-    for(int k=0;k<3;k++)
-      cam_rgb_spec[k] = spectrum_integrate(cfa_spec, k, cfa_spec_cnt, cf, 3);
-    normalise1(cam_rgb_spec);
-    double u0 = cam_rgb_spec[0], u1 = cam_rgb_spec[2];
-    tri2quad(&u0, &u1);
-    float fxy[] = {xy[0], xy[1]}, white[] = {1.0f/3.0f, 1.0f/3.0f};
-    float sat = dt_spectrum_saturation(fxy, white);
-    // find angular max dist + sat
-    int bin = CLAMP(180.0/M_PI * (M_PI + atan2(u1-white_cam_rgb[2], u0-white_cam_rgb[0])), 0, 359);
-    double dist2 =
-      (u1-white_cam_rgb[2])*(u1-white_cam_rgb[2])+
-      (u0-white_cam_rgb[0])*(u0-white_cam_rgb[0]);
-    if(dist2 > angular_ds[2*bin])
-    {
-      angular_ds[2*bin+0] = dist2;
-      angular_ds[2*bin+1] = sat;
-    }
-  }
-
-  // 2nd pass:
-// #pragma omp parallel for schedule(dynamic) collapse(2) default(shared)
-  for(int j=0;j<sht;j++) for(int i=0;i<swd;i++)
-  {
-    double xy[2] = {(i+0.5)/swd, (j+0.5)/sht};
-    quad2tri(xy+0, xy+1);
 
     double cf[3]; // look up the coeffs for the sampled colour spectrum
-    fetch_coeff(xy, spectra, sh->wd, sh->ht, cf); // interpolate
-    // fetch_coeffi(xy, spectra, sh->wd, sh->ht, cf); // nearest
+    fetch_coeff(xy, spectra, sh->wd, sh->ht, cf); // bilinear
     if(cf[0] == 0) continue; // discard out of spectral locus
 
     double cam_rgb_spec[3] = {0.0}; // camera rgb by processing spectrum * cfa spectrum
     for(int k=0;k<3;k++)
       cam_rgb_spec[k] = spectrum_integrate(cfa_spec, k, cfa_spec_cnt, cf, 3);
     const double cam_rgb_L1 = normalise1(cam_rgb_spec);
-    double xyz_spec[3] = {0.0}; // camera rgb by processing spectrum * cfa spectrum
+    double xyz_spec2[3] = {0.0};
     for(int k=0;k<3;k++)
-      xyz_spec[k] = spectrum_integrate(cie_spec, k, cie_spec_cnt, cf, 3);
-    double rec2020[3];
-    mat3_mulv(xyz_to_rec2020, xyz_spec, rec2020);
-    const double rec2020_L1 = normalise1(rec2020) * ref_L;
-
-    float fxy[] = {xy[0], xy[1]}, white[2] = {1.0f/3.0f, 1.0f/3.0f};
-    float sat = dt_spectrum_saturation(fxy, white);
+      xyz_spec2[k] = spectrum_integrate(cie_spec, k, cie_spec_cnt, cf, 3);
+    double rec2020_s[3];
+    mat3_mulv(xyz_to_rec2020, xyz_spec2, rec2020_s);
+    const double rec2020_L1 = normalise1(rec2020_s) * ref_L;
 
     // convert tri t to quad u:
     double u0 = cam_rgb_spec[0], u1 = cam_rgb_spec[2];
     tri2quad(&u0, &u1);
+    if(u0 < 0 || u1 < 0 || u0 > 1.0 || u1 > 1.0) continue; // outside output grid
 
-    int bin = CLAMP(180.0/M_PI * (M_PI + atan2(u1-white_cam_rgb[2], u0-white_cam_rgb[0])), 0, 359);
-    double dist2 =
-      (u1-white_cam_rgb[2])*(u1-white_cam_rgb[2])+
-      (u0-white_cam_rgb[0])*(u0-white_cam_rgb[0]);
-    if(dist2 < angular_ds[2*bin] && sat > angular_ds[2*bin+1])
-      continue; // discard higher xy sat for lower rgb sat
-    if(dist2 < 0.8*0.8*angular_ds[2*bin] && sat > 0.95*angular_ds[2*bin+1])
-      continue; // be harsh to values straddling our bounds
+    int ii = CLAMP((int)(u0 * wd), 0, wd-1);
+    int jj = CLAMP((int)(u1 * ht), 0, ht-1);
+    double cx = (ii+0.5)/wd, cy = (jj+0.5)/ht;
+    double dd = (u0-cx)*(u0-cx) + (u1-cy)*(u1-cy);
 
-    // sort this into rb/sum(rgb) map in camera rgb
-    int ii = CLAMP(u0 * wd + 0.5, 0, wd-1);
-    int jj = CLAMP(u1 * ht + 0.5, 0, ht-1);
+    uint64_t bidx = (uint64_t)jj*wd + ii;
+    if(dd >= bestd[bidx]) continue; // a closer sample already claimed this bin
+    bestd[bidx] = dd;
 
-    buf[3*(jj*wd + ii)+0] = rec2020[0];
-    buf[3*(jj*wd + ii)+1] = rec2020[2];
-    buf[3*(jj*wd + ii)+2] = rec2020_L1 / cam_rgb_L1;
+    buf[3*bidx+0] = rec2020_s[0];
+    buf[3*bidx+1] = rec2020_s[2];
+    buf[3*bidx+2] = rec2020_L1 / cam_rgb_L1;
   }
-  free(angular_ds);
+  free(bestd);
 
   *wd_out = wd;
   *ht_out = ht;
   return buf;
 }
 
-// write look up table based on hue and chroma:
+// Write chroma bands and packed luminance pairs; n==2 uses the legacy layout.
 static inline void
-write_chroma_lut(
-    const char  *basename,
-    const float *buf0,
-    const float *buf1,
-    const int    wd,
-    const int    ht)
+write_chroma_lut_n(
+    const char   *basename,
+    float       **clut, // n buffers, each in create_chroma_lut's buf layout
+    const int     n,
+    const int     wd,
+    const int     ht)
 {
+  const int nbands = (n == 2) ? 3 : (n + (n+1)/2);
   dt_lut_header_t hout = {
     .magic    = dt_lut_header_magic,
     .version  = dt_lut_header_version,
     .channels = 2,
     .datatype = dt_lut_header_f16,
-    .wd       = 3*wd,
+    .wd       = nbands*wd,
     .ht       = ht,
   };
   char filename[256] = {0};
   snprintf(filename, sizeof(filename), "%s.lut", basename);
   FILE *f = fopen(filename, "wb");
   fwrite(&hout, sizeof(hout), 1, f);
-  uint16_t *b16 = calloc(sizeof(uint16_t), wd*(uint64_t)ht*6);
+  uint16_t *b16 = calloc(sizeof(uint16_t), wd*(uint64_t)ht*nbands*2);
   for(int j=0;j<ht;j++) for(int i=0;i<wd;i++)
   {
-    b16[2*(3*wd*j+i)+0]      = float_to_half(buf0[3*(wd*j+i)+0]);
-    b16[2*(3*wd*j+i)+1]      = float_to_half(buf0[3*(wd*j+i)+1]);
-    b16[2*(3*wd*j+i+wd)+0]   = float_to_half(buf0[3*(wd*j+i)+2]);
-    b16[2*(3*wd*j+i+wd)+1]   = float_to_half(buf1[3*(wd*j+i)+2]);
-    b16[2*(3*wd*j+i+2*wd)+0] = float_to_half(buf1[3*(wd*j+i)+0]);
-    b16[2*(3*wd*j+i+2*wd)+1] = float_to_half(buf1[3*(wd*j+i)+1]);
+    const uint64_t px = (uint64_t)wd*j+i;
+    if(n == 2)
+    { // Legacy layout.
+      b16[2*(3*wd*j+i)+0]      = float_to_half(clut[0][3*px+0]);
+      b16[2*(3*wd*j+i)+1]      = float_to_half(clut[0][3*px+1]);
+      b16[2*(3*wd*j+i+wd)+0]   = float_to_half(clut[0][3*px+2]);
+      b16[2*(3*wd*j+i+wd)+1]   = float_to_half(clut[1][3*px+2]);
+      b16[2*(3*wd*j+i+2*wd)+0] = float_to_half(clut[1][3*px+0]);
+      b16[2*(3*wd*j+i+2*wd)+1] = float_to_half(clut[1][3*px+1]);
+      continue;
+    }
+    const uint64_t row = (uint64_t)nbands*wd*j;
+    for(int a=0;a<n;a++)
+    {
+      b16[2*(row + a*wd + i)+0] = float_to_half(clut[a][3*px+0]);
+      b16[2*(row + a*wd + i)+1] = float_to_half(clut[a][3*px+1]);
+    }
+    for(int p=0;p<(n+1)/2;p++)
+    {
+      const int a0 = 2*p, a1 = (2*p+1 < n) ? 2*p+1 : 2*p;
+      const uint64_t bidx = row + (uint64_t)(n+p)*wd + i;
+      b16[2*bidx+0] = float_to_half(clut[a0][3*px+2]);
+      b16[2*bidx+1] = float_to_half(clut[a1][3*px+2]);
+    }
   }
-  fwrite(b16, sizeof(uint16_t), wd*(uint64_t)ht*6, f);
+  fwrite(b16, sizeof(uint16_t), wd*(uint64_t)ht*nbands*2, f);
   // append metadata, the source spectrum:
   fprintf(f, "##### created by vkdt mkclut, from following input\n");
   snprintf(filename, sizeof(filename), "%s.txt", basename);
@@ -218,16 +314,24 @@ write_chroma_lut(
   free(b16);
 }
 
+// Fixed grid shared with colour/main.c.
+#define MKCLUT_ANCHOR_T_LO 2000.0
+#define MKCLUT_ANCHOR_T_HI 15000.0
+
 int main(int argc, char *argv[])
 {
   const char *model = 0;
   const char *illum_file0 = "data/cie_d65";
   const char *illum_file1 = "data/cie_a";
+  int n_nanchor = 0;
+  int have_nanchor = 0;
+  int ss = 8;
   for(int k=1;k<argc;k++)
   {
-    if     (!strcmp(argv[k], "--illum")  && argc > k+1) illum_file0 = argv[++k];
-    else if(!strcmp(argv[k], "--illum0") && argc > k+1) illum_file0 = argv[++k];
+    if     (!strcmp(argv[k], "--illum0") && argc > k+1) illum_file0 = argv[++k];
     else if(!strcmp(argv[k], "--illum1") && argc > k+1) illum_file1 = argv[++k];
+    else if(!strcmp(argv[k], "--nanchor") && argc > k+1) { n_nanchor = atol(argv[++k]); have_nanchor = 1; }
+    else if(!strcmp(argv[k], "--ss")      && argc > k+1) ss = MAX(1, atol(argv[++k]));
     else model = argv[k];
   }
   if(!model)
@@ -236,9 +340,21 @@ int main(int argc, char *argv[])
     fprintf(stderr, "usage: mkclut <cam model>       load ssf from 'cam model.txt',\n"
                     "                                write 'cam model.lut'\n"
                     "              --illum0 <xx>     illuminant 0, default d65 (daylight)\n"
-                    "              --illum1 <yy>     illuminant 1, default a (incandescent)\n");
+                    "              --illum1 <yy>     illuminant 1, default a (incandescent)\n"
+                    "              --nanchor <n>     generate n anchors mired-spaced from\n"
+                    "                                2000-15000k. this is what\n"
+                    "                                the colour module's temp slider assumes for\n"
+                    "                                n>=3 anchor cluts.\n"
+                    "              --ss <n>          source oversampling factor, default 8.\n"
+                    "                                pure quality/runtime knob, see\n"
+                    "                                create_chroma_lut's comment.\n");
     exit(1);
   }
+  if(have_nanchor)
+  {
+    n_nanchor = CLAMP(n_nanchor, 3, MKCLUT_MAX_ANCHORS);
+  }
+  const int n_anchor = have_nanchor ? n_nanchor : 2;
 
   dt_lut_header_t sp_header;
   char filename[PATH_MAX+30], basedir[PATH_MAX];
@@ -258,8 +374,8 @@ int main(int argc, char *argv[])
   int d65_cnt = spectrum_load(filename, d65_spec);
 
   int clut_wd, clut_ht;
-  float *clut0, *clut1;
-  for(int ill=0;ill<2;ill++)
+  float *clut[MKCLUT_MAX_ANCHORS];
+  for(int ill=0;ill<n_anchor;ill++)
   {
     snprintf(filename, sizeof(filename), "%s/data/cie_observer", basedir);
     int cfa_spec_cnt = spectrum_load(model,    cfa_spec);
@@ -271,9 +387,19 @@ int main(int argc, char *argv[])
     }
     cfa_spec_cnt = spectrum_chg_interval( cfa_spec, cfa_spec_cnt, 5); //interpolates spectrum to 5nm intervals
     double illum_spec[1000][4];
-    snprintf(filename, sizeof(filename), "%s/%s", basedir, ill ? illum_file1 : illum_file0);
-    int illum_cnt = spectrum_load(filename, illum_spec);
-    if(!illum_cnt) 
+    int illum_cnt;
+    if(have_nanchor)
+    {
+      const double m_lo = 1e6/MKCLUT_ANCHOR_T_HI, m_hi = 1e6/MKCLUT_ANCHOR_T_LO;
+      const double m = m_lo + (m_hi-m_lo)*ill/(double)(n_anchor-1);
+      illum_cnt = synth_illuminant(1e6/m, illum_spec);
+    }
+    else
+    {
+      snprintf(filename, sizeof(filename), "%s/%s", basedir, ill ? illum_file1 : illum_file0);
+      illum_cnt = spectrum_load(filename, illum_spec);
+    }
+    if(!illum_cnt)
     {
       fprintf(stderr, "[mkclut] could not open illumination spectrum %s!\n", ill ? illum_file1 : illum_file0);
       exit(3);
@@ -287,14 +413,14 @@ int main(int argc, char *argv[])
     // anything). this only works if we also apply D65 when computing the reference:
     spectrum_wb(cie_spec_cnt, d65_cnt, cie_spec, d65_spec);
 
-    float **clut = (ill ? &clut1 : &clut0);
-    *clut = create_chroma_lut(
+    clut[ill] = create_chroma_lut(
         &clut_wd, &clut_ht,
         sp_buf, &sp_header,
         cfa_spec,
         cfa_spec_cnt,
         cie_spec,
-        cie_spec_cnt);
+        cie_spec_cnt,
+        ss);
 
 #if 0
     if(ill == 0)
@@ -307,7 +433,7 @@ int main(int argc, char *argv[])
       for(int i=0;i<clut_wd;i++)
       {
         int k = (clut_ht-1-j)*clut_wd + i; // fucking flip so convert -> png shows correctly
-        float col[3] = {clut0[3*k], clut0[3*k+1], 1.0-clut0[3*k]-clut0[3*k+1]};
+        float col[3] = {clut[0][3*k], clut[0][3*k+1], 1.0-clut[0][3*k]-clut[0][3*k+1]};
         uint8_t c8[3] = {
           // CLAMP(256*(i+0.5)/clut_wd, 0, 255),
           // CLAMP(256*(j+0.5)/clut_ht, 0, 255),
@@ -323,7 +449,7 @@ int main(int argc, char *argv[])
 #endif
 
     dt_inpaint_buf_t inpaint_buf = {
-      .dat = (ill ? clut1 : clut0),
+      .dat = clut[ill],
       .wd  = clut_wd,
       .ht  = clut_ht,
       .cpp = 3,
@@ -331,11 +457,10 @@ int main(int argc, char *argv[])
     dt_inpaint(&inpaint_buf);
   }
 
-  write_chroma_lut(model, clut0, clut1, clut_wd, clut_ht);
+  write_chroma_lut_n(model, clut, n_anchor, clut_wd, clut_ht);
 
   free(sp_buf);
-  free(clut0);
-  free(clut1);
+  for(int ill=0;ill<n_anchor;ill++) free(clut[ill]);
 
   exit(0);
 }

--- a/src/tools/clut/src/mkclut.c
+++ b/src/tools/clut/src/mkclut.c
@@ -162,7 +162,7 @@ create_chroma_lut_DEBUG(
 }
 #endif
 
-// Scatter spectral samples into camera-chroma bins.
+// create 2.5D chroma lut
 static inline float*
 create_chroma_lut(
     int                   *wd_out,
@@ -175,18 +175,19 @@ create_chroma_lut(
     const int              cie_spec_cnt,
     const int              ss)              // source oversampling factor
 {
-  int wd = sh->wd, ht = sh->ht; // output dimensions
+  int swd = sh->wd, sht = sh->ht; // sampling dimensions
+  int wd  = swd, ht = sht; // output dimensions
   float *buf = calloc(sizeof(float)*3, wd*ht+1);
-  double *bestd = malloc(sizeof(double)*wd*(uint64_t)ht);
-  for(uint64_t k=0;k<wd*(uint64_t)ht;k++) bestd[k] = 1e300;
 
-  // Illuminant-E reference luminance.
+  // do two passes over the data
+  // get illum E white point (lowest saturation) in camera rgb and quad param:
   const double wcf[] = {0.0, 0.0, 100000.0}; // illuminant E
   double white_cam_rgb[3] = {
     spectrum_integrate(cfa_spec, 0, cfa_spec_cnt, wcf, 3),
     spectrum_integrate(cfa_spec, 1, cfa_spec_cnt, wcf, 3),
     spectrum_integrate(cfa_spec, 2, cfa_spec_cnt, wcf, 3)};
   const double white_cam_rgb_L1 = normalise1(white_cam_rgb);
+  tri2quad(white_cam_rgb, white_cam_rgb+2);
   double xyz_spec[3] = {0.0};
   for(int k=0;k<3;k++)
     xyz_spec[k] = spectrum_integrate(cie_spec, k, cie_spec_cnt, wcf, 3);
@@ -195,14 +196,43 @@ create_chroma_lut(
   const double white_rec2020_L1 = normalise1(rec2020);
   const double ref_L = white_cam_rgb_L1 / white_rec2020_L1;
 
-  // Oversample the source grid.
-  const int sample_wd = wd*ss, sample_ht = ht*ss;
-
+  // first pass: get rough idea about max deviation from white and the saturation we got there
+  double *angular_ds = calloc(sizeof(double), 360*2);
+  int sample_wd = swd, sample_ht = sht;
   for(int j=0;j<sample_ht;j++) for(int i=0;i<sample_wd;i++)
   {
     double xy[2] = {(i+0.5)/sample_wd, (j+0.5)/sample_ht};
     quad2tri(xy+0, xy+1);
+    double cf[3]; // look up the coeffs for the sampled colour spectrum
+    fetch_coeffi(xy, spectra, sh->wd, sh->ht, cf); // nearest
+    if(cf[0] == 0) continue; // discard out of spectral locus
+    double cam_rgb_spec[3] = {0.0}; // camera rgb by processing spectrum * cfa spectrum
+    for(int k=0;k<3;k++)
+      cam_rgb_spec[k] = spectrum_integrate(cfa_spec, k, cfa_spec_cnt, cf, 3);
+    normalise1(cam_rgb_spec);
+    double u0 = cam_rgb_spec[0], u1 = cam_rgb_spec[2];
+    tri2quad(&u0, &u1);
+    float fxy[] = {xy[0], xy[1]}, white[] = {1.0f/3.0f, 1.0f/3.0f};
+    float sat = dt_spectrum_saturation(fxy, white);
+    // find angular max dist + sat
+    int bin = CLAMP(180.0/M_PI * (M_PI + atan2(u1-white_cam_rgb[2], u0-white_cam_rgb[0])), 0, 359);
+    double dist2 =
+      (u1-white_cam_rgb[2])*(u1-white_cam_rgb[2])+
+      (u0-white_cam_rgb[0])*(u0-white_cam_rgb[0]);
+    if(dist2 > angular_ds[2*bin])
+    {
+      angular_ds[2*bin+0] = dist2;
+      angular_ds[2*bin+1] = sat;
+    }
+  }
 
+  // 2nd pass:
+// #pragma omp parallel for schedule(dynamic) collapse(2) default(shared)
+  sample_wd = swd*ss, sample_ht = sht*ss;
+  for(int j=0;j<sample_ht;j++) for(int i=0;i<sample_wd;i++)
+  {
+    double xy[2] = {(i+0.5)/sample_wd, (j+0.5)/sample_ht};
+    quad2tri(xy+0, xy+1);
     double cf[3]; // look up the coeffs for the sampled colour spectrum
     fetch_coeff(xy, spectra, sh->wd, sh->ht, cf); // bilinear
     if(cf[0] == 0) continue; // discard out of spectral locus
@@ -211,32 +241,36 @@ create_chroma_lut(
     for(int k=0;k<3;k++)
       cam_rgb_spec[k] = spectrum_integrate(cfa_spec, k, cfa_spec_cnt, cf, 3);
     const double cam_rgb_L1 = normalise1(cam_rgb_spec);
-    double xyz_spec2[3] = {0.0};
+    double xyz_spec[3] = {0.0}; // camera rgb by processing spectrum * cfa spectrum
     for(int k=0;k<3;k++)
-      xyz_spec2[k] = spectrum_integrate(cie_spec, k, cie_spec_cnt, cf, 3);
-    double rec2020_s[3];
-    mat3_mulv(xyz_to_rec2020, xyz_spec2, rec2020_s);
-    const double rec2020_L1 = normalise1(rec2020_s) * ref_L;
+      xyz_spec[k] = spectrum_integrate(cie_spec, k, cie_spec_cnt, cf, 3);
+    double rec2020[3];
+    mat3_mulv(xyz_to_rec2020, xyz_spec, rec2020);
+    const double rec2020_L1 = normalise1(rec2020) * ref_L;
 
+    float fxy[] = {xy[0], xy[1]}, white[2] = {1.0f/3.0f, 1.0f/3.0f};
+    float sat = dt_spectrum_saturation(fxy, white);
     // convert tri t to quad u:
     double u0 = cam_rgb_spec[0], u1 = cam_rgb_spec[2];
     tri2quad(&u0, &u1);
-    if(u0 < 0 || u1 < 0 || u0 > 1.0 || u1 > 1.0) continue; // outside output grid
+    int bin = CLAMP(180.0/M_PI * (M_PI + atan2(u1-white_cam_rgb[2], u0-white_cam_rgb[0])), 0, 359);
+    double dist2 =
+      (u1-white_cam_rgb[2])*(u1-white_cam_rgb[2])+
+      (u0-white_cam_rgb[0])*(u0-white_cam_rgb[0]);
+    if(dist2 < angular_ds[2*bin] && sat > angular_ds[2*bin+1])
+      continue; // discard higher xy sat for lower rgb sat
+    if(dist2 < 0.8*0.8*angular_ds[2*bin] && sat > 0.95*angular_ds[2*bin+1])
+      continue; // be harsh to values straddling our bounds
 
-    int ii = CLAMP((int)(u0 * wd), 0, wd-1);
-    int jj = CLAMP((int)(u1 * ht), 0, ht-1);
-    double cx = (ii+0.5)/wd, cy = (jj+0.5)/ht;
-    double dd = (u0-cx)*(u0-cx) + (u1-cy)*(u1-cy);
+    // sort this into rb/sum(rgb) map in camera rgb
+    int ii = CLAMP(u0 * wd + 0.5, 0, wd-1);
+    int jj = CLAMP(u1 * ht + 0.5, 0, ht-1);
 
-    uint64_t bidx = (uint64_t)jj*wd + ii;
-    if(dd >= bestd[bidx]) continue; // a closer sample already claimed this bin
-    bestd[bidx] = dd;
-
-    buf[3*bidx+0] = rec2020_s[0];
-    buf[3*bidx+1] = rec2020_s[2];
-    buf[3*bidx+2] = rec2020_L1 / cam_rgb_L1;
+    buf[3*(jj*wd + ii)+0] = rec2020[0];
+    buf[3*(jj*wd + ii)+1] = rec2020[2];
+    buf[3*(jj*wd + ii)+2] = rec2020_L1 / cam_rgb_L1;
   }
-  free(bestd);
+  free(angular_ds);
 
   *wd_out = wd;
   *ht_out = ht;


### PR DESCRIPTION
After getting something of an approximate input device transform for my camera working, I was kind of wishing for a way to actually white balance using the temp slider. Ended up feeling restricted by the dual illuminant interpolation, so implemented multi-anchor clut generation, and added support for those in the colour module, extended slider range to cover more temperatures, and added an auto temperature calculation that estimates the image cct from the raw metadata by finding what clut evaluation temperature would give the most neutral output. Additionally, can use a picked patch as a temp target by choosing temp as picked target and setting temp to 0. 

Everything works with older dual-illuminant luts too. 