### PR TITLE
dr: show thumbnail placeholder while pipeline processes

### DIFF
--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -141,6 +141,12 @@ typedef struct dt_gui_wstate_t
   int lighttable_images_per_row;// how many images per row in lighttable mode
 
   double delta_time;            // time passed since last frame in seconds
+
+  // Placeholder thumbnail for darkroom while pipeline processes
+  VkDescriptorSet   dr_placeholder_dset;   // thumbnail descriptor set
+  float             dr_placeholder_wd;     // thumbnail width in texels
+  float             dr_placeholder_ht;     // thumbnail height in texels
+  int               dr_placeholder_valid;  // 1 if we have a valid placeholder
 }
 dt_gui_wstate_t;
 

--- a/src/gui/render_darkroom.c
+++ b/src/gui/render_darkroom.c
@@ -411,7 +411,6 @@ void render_darkroom_full(char *filter_name, char *filter_inst)
 
 void render_darkroom()
 {
-  // double clock_beg = dt_time();
 
   int win_x = vkdt.state.center_x,  win_y = vkdt.state.center_y;
   int win_w = vkdt.state.center_wd, win_h = vkdt.state.center_ht - vkdt.wstate.dopesheet_view;
@@ -450,13 +449,24 @@ void render_darkroom()
   if(nk_begin(&vkdt.ctx, "darkroom center", bounds, NK_WINDOW_NO_SCROLLBAR | (disabled ? NK_WINDOW_NO_INPUT : 0)))
   { // draw center view image:
     dt_node_t *out_main = dt_graph_get_display(&vkdt.graph_dev, dt_token("main"));
-    if(out_main)
+    int rdy = out_main && (vkdt.graph_res[display_frame] == VK_SUCCESS);
+    int events = !vkdt.wstate.grabbed && !disabled;
+    // center view has on-canvas widgets (but only if there *is* an image):
+    nk_layout_row_dynamic(&vkdt.ctx, win_h, 1);
+
+    int show_placeholder = !rdy && vkdt.wstate.dr_placeholder_valid;
+    if(show_placeholder)
     {
-      int rdy = vkdt.graph_res[display_frame] == VK_SUCCESS;
-      int events = !vkdt.wstate.grabbed && !disabled;
-      // center view has on-canvas widgets (but only if there *is* an image):
-      nk_layout_row_dynamic(&vkdt.ctx, win_h, 1);
-      dt_image(&vkdt.ctx, &vkdt.wstate.img_widget, out_main, events, out_main != 0, 1, rdy);
+      dt_image_draw_placeholder(
+          &vkdt.ctx, &vkdt.wstate.img_widget,
+          vkdt.wstate.dr_placeholder_dset,
+          vkdt.wstate.dr_placeholder_wd,
+          vkdt.wstate.dr_placeholder_ht);
+    }
+    else if(out_main)
+    {
+      dt_image(&vkdt.ctx, &vkdt.wstate.img_widget, out_main, events,
+               out_main != 0, 1, rdy);
     }
     float wd = 0.8*win_y;
     const uint32_t ci = dt_db_current_imgid(&vkdt.db);
@@ -1245,7 +1255,8 @@ darkroom_process()
     // 1-double buffer is still running on gpu, has not been swapped in yet
     int running = (vkdt.graph_res[vkdt.graph_dev.double_buffer^1] == -1);
     if(running)
-    {
+    { // keep the loop awake while the back buffer is still rendering on the gpu
+      vkdt.wstate.busy++;
       uint64_t value;
       VkResult res = vkGetSemaphoreCounterValue(qvk.device, vkdt.graph_dev.semaphore_process, &value);
       if(res == VK_SUCCESS && value >= vkdt.graph_dev.process_dbuffer[vkdt.graph_dev.double_buffer^1])
@@ -1262,6 +1273,8 @@ darkroom_process()
     // we'll wait for the other one after execution (potential gui lockup, but faster for anim)
 #endif
 
+    // If placeholder is valid, the graph output isn't ready yet, so render_darkroom()
+    // shows the thumbnail. Once the graph finishes, it will draw the full image.
     if(!running && vkdt.graph_dev.runflags) // stills and stopped animations
     { // double buffered async compute
       vkdt.graph_dev.double_buffer ^= 1; // work on the one that's not currently locked
@@ -1326,7 +1339,20 @@ darkroom_process()
 
 int
 darkroom_enter()
-{
+{ // capture the current image's thumbnail as a darkroom placeholder while the full-res pipeline runs
+  uint32_t imgid = dt_db_current_imgid(&vkdt.db);
+  vkdt.wstate.dr_placeholder_valid = 0;
+  if(imgid != -1u)
+  {
+    const uint32_t tid = vkdt.db.image[imgid].thumbnail;
+    if(tid > 0 && tid < vkdt.thumbnails.thumb_max)
+    {
+      vkdt.wstate.dr_placeholder_dset = vkdt.thumbnails.thumb[tid].dset;
+      vkdt.wstate.dr_placeholder_wd   = vkdt.thumbnails.thumb[tid].wd;
+      vkdt.wstate.dr_placeholder_ht   = vkdt.thumbnails.thumb[tid].ht;
+      vkdt.wstate.dr_placeholder_valid = 1;
+    }
+  }
   vkdt.wstate.lod_fine     = dt_rc_get_int(&vkdt.rc, "gui/lod", 1); // set finest lod by default
   vkdt.wstate.lod_interact = dt_rc_get_int(&vkdt.rc, "gui/lod_interact", 1);
   vkdt.state.anim_frame = 0;
@@ -1339,7 +1365,7 @@ darkroom_enter()
   dt_radial_menu_dr_close(&vkdt.wstate.radial_menu_dr);
   vkdt.wstate.mapped = 0;
   vkdt.wstate.selected = -1;
-  uint32_t imgid = dt_db_current_imgid(&vkdt.db);
+  imgid = dt_db_current_imgid(&vkdt.db);
   if(imgid == -1u) return 1;
   char graph_cfg[PATH_MAX+100];
   dt_db_image_path(&vkdt.db, imgid, graph_cfg, sizeof(graph_cfg));
@@ -1492,6 +1518,7 @@ darkroom_leave()
   dt_graph_repurpose(&vkdt.graph_dev);
   dt_graph_history_cleanup(&vkdt.graph_dev);
   vkdt.graph_res[0] = vkdt.graph_res[1] = VK_INCOMPLETE; // invalidate
+  vkdt.wstate.dr_placeholder_valid = 0;  // clear placeholder on exit
   dt_dragkeys_cancel(&dragkeys);
   dt_gamepadhelp_clear();
   dt_keyhelp_clear();

--- a/src/gui/widget_image.h
+++ b/src/gui/widget_image.h
@@ -436,3 +436,31 @@ dt_image(
   // now the controls:
   if(events) dt_image_events(ctx, w, hover, main, disp);
 }
+
+// Draw a thumbnail as placeholder while the full-res pipeline is still processing.
+// Simple fit-to-view — no zoom/pan interaction. Both thumbnail and full-res
+// have the same aspect ratio, so swapping at fit-to-view is seamless.
+static inline void
+dt_image_draw_placeholder(
+    struct nk_context *ctx,
+    dt_image_widget_t *w,
+    VkDescriptorSet dset,
+    float thumb_wd,
+    float thumb_ht)
+{
+  struct nk_rect wb = nk_widget_bounds(ctx);
+
+  float scale = MIN(wb.w / thumb_wd, wb.h / thumb_ht);
+  float disp_w = thumb_wd * scale;
+  float disp_h = thumb_ht * scale;
+  struct nk_rect disp = {
+    wb.x + (wb.w - disp_w) * 0.5f,
+    wb.y + (wb.h - disp_h) * 0.5f,
+    disp_w, disp_h
+  };
+
+  struct nk_command_buffer *buf = nk_window_get_canvas(ctx);
+  struct nk_image nkimg = nk_subimage_ptr(dset, thumb_wd, thumb_ht,
+      (struct nk_rect){0, 0, thumb_wd, thumb_ht});
+  nk_draw_image(buf, disp, &nkimg, (struct nk_color){0xff,0xff,0xff,0xff});
+}


### PR DESCRIPTION
During testing of #294 I noticed that it is hard to tell if a double click was registered, because there is no immediate feedback: while the pipeline runs, the lighttable continues to be displayed (frozen). This state lasts for about 3s on my laptop.

[Here](https://discuss.pixls.us/t/installed-at-last-but-unusable/59658/4) , I read 

> Unfortunately your gpu seems to only expose one vulkan queue so you do not benefit from running compute asynchronously from the gui

So this issue might only be present/pronounced on this class of old and slow GPUs.

To fix the "no immediate reaction to user action" issue, I figured it would be best to enter the darkroom immediately, and show the thumbnail (enlarged) while the full res pipeline is still running. I tried to keep complexity and amount of code as low as possible.

Let me know if you find this feature valuable and if it behaves well on your (faster) systems. The most important things for features that only slow systems benefit from, is, that they don't hurt on faster systems (I'd say).